### PR TITLE
Update WELSPECS.fodt for 2023-10

### DIFF
--- a/parts/chapters/subsections/12.3/WELSPECS.fodt
+++ b/parts/chapters/subsections/12.3/WELSPECS.fodt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:officeooo="http://openoffice.org/2009/office" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
- <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT5H33M29S</meta:editing-duration><meta:editing-cycles>24</meta:editing-cycles><meta:generator>LibreOffice/7.6.2.1$Windows_X86_64 LibreOffice_project/56f7684011345957bbf33a7ee678afaf4d2ba333</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
+ <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT5H33M42S</meta:editing-duration><meta:editing-cycles>25</meta:editing-cycles><meta:generator>LibreOffice/7.6.2.1$Windows_X86_64 LibreOffice_project/56f7684011345957bbf33a7ee678afaf4d2ba333</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
 1) eq 
 2) F3
 
@@ -17,24 +17,24 @@ To insert a new keyword section (except for the header
 To insert standard text:
 1) t0, t1, t2
 2) F3
-Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:initial-creator>David Baxendale</meta:initial-creator><dc:date>2023-12-11T16:00:37.903000000</dc:date><meta:document-statistic meta:table-count="9" meta:image-count="0" meta:object-count="0" meta:page-count="5" meta:paragraph-count="231" meta:word-count="2278" meta:character-count="13971" meta:non-whitespace-character-count="10728"/><meta:user-defined meta:name="ClientContact">ClientContact</meta:user-defined><meta:user-defined meta:name="ClientEmail">ClientEmail</meta:user-defined><meta:user-defined meta:name="ClientName">Equinor ASA</meta:user-defined><meta:user-defined meta:name="ClientOffice">ClientOfficeAddres</meta:user-defined><meta:user-defined meta:name="ClientRegistered" meta:value-type="string">ClientRegisteredAddress</meta:user-defined><meta:user-defined meta:name="ClientTelNo" meta:value-type="string">ClientTelNo</meta:user-defined><meta:user-defined meta:name="DocumentDate" meta:value-type="string">June 8, 2023</meta:user-defined><meta:user-defined meta:name="DocumentNumber" meta:value-type="string">2023-04-RPT</meta:user-defined><meta:user-defined meta:name="DocumentRevision" meta:value-type="string">Rev-0</meta:user-defined><meta:user-defined meta:name="ProgramVersion" meta:value-type="string">2023-04</meta:user-defined></office:meta>
+Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:initial-creator>David Baxendale</meta:initial-creator><dc:date>2023-12-12T14:54:01.837000000</dc:date><meta:document-statistic meta:table-count="9" meta:image-count="0" meta:object-count="0" meta:page-count="5" meta:paragraph-count="231" meta:word-count="2288" meta:character-count="14056" meta:non-whitespace-character-count="10803"/><meta:user-defined meta:name="ClientContact">ClientContact</meta:user-defined><meta:user-defined meta:name="ClientEmail">ClientEmail</meta:user-defined><meta:user-defined meta:name="ClientName">Equinor ASA</meta:user-defined><meta:user-defined meta:name="ClientOffice">ClientOfficeAddres</meta:user-defined><meta:user-defined meta:name="ClientRegistered" meta:value-type="string">ClientRegisteredAddress</meta:user-defined><meta:user-defined meta:name="ClientTelNo" meta:value-type="string">ClientTelNo</meta:user-defined><meta:user-defined meta:name="DocumentDate" meta:value-type="string">June 8, 2023</meta:user-defined><meta:user-defined meta:name="DocumentNumber" meta:value-type="string">2023-04-RPT</meta:user-defined><meta:user-defined meta:name="DocumentRevision" meta:value-type="string">Rev-0</meta:user-defined><meta:user-defined meta:name="ProgramVersion" meta:value-type="string">2023-04</meta:user-defined></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
-   <config:config-item config:name="ViewAreaTop" config:type="long">119168</config:config-item>
+   <config:config-item config:name="ViewAreaTop" config:type="long">127090</config:config-item>
    <config:config-item config:name="ViewAreaLeft" config:type="long">0</config:config-item>
    <config:config-item config:name="ViewAreaWidth" config:type="long">21500</config:config-item>
-   <config:config-item config:name="ViewAreaHeight" config:type="long">24370</config:config-item>
+   <config:config-item config:name="ViewAreaHeight" config:type="long">24384</config:config-item>
    <config:config-item config:name="ShowRedlineChanges" config:type="boolean">true</config:config-item>
    <config:config-item config:name="InBrowseMode" config:type="boolean">false</config:config-item>
    <config:config-item-map-indexed config:name="Views">
     <config:config-item-map-entry>
      <config:config-item config:name="ViewId" config:type="string">view2</config:config-item>
-     <config:config-item config:name="ViewLeft" config:type="long">10682</config:config-item>
-     <config:config-item config:name="ViewTop" config:type="long">137823</config:config-item>
+     <config:config-item config:name="ViewLeft" config:type="long">8851</config:config-item>
+     <config:config-item config:name="ViewTop" config:type="long">135881</config:config-item>
      <config:config-item config:name="VisibleLeft" config:type="long">0</config:config-item>
-     <config:config-item config:name="VisibleTop" config:type="long">119168</config:config-item>
+     <config:config-item config:name="VisibleTop" config:type="long">127090</config:config-item>
      <config:config-item config:name="VisibleRight" config:type="long">21498</config:config-item>
-     <config:config-item config:name="VisibleBottom" config:type="long">143536</config:config-item>
+     <config:config-item config:name="VisibleBottom" config:type="long">151472</config:config-item>
      <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutColumns" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutBookMode" config:type="boolean">false</config:config-item>
@@ -116,7 +116,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <config:config-item config:name="LoadReadonly" config:type="boolean">false</config:config-item>
    <config:config-item config:name="ClipAsCharacterAnchoredWriterFlyFrames" config:type="boolean">false</config:config-item>
    <config:config-item config:name="UseOldPrinterMetrics" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="Rsid" config:type="int">1844699</config:config-item>
+   <config:config-item config:name="Rsid" config:type="int">1864383</config:config-item>
    <config:config-item config:name="RsidRoot" config:type="int">130112</config:config-item>
    <config:config-item config:name="ProtectForm" config:type="boolean">false</config:config-item>
    <config:config-item config:name="MsWordCompTrailingBlanks" config:type="boolean">false</config:config-item>
@@ -508,7 +508,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
   </draw:fill-image>
   <style:default-style style:family="graphic">
    <style:graphic-properties svg:stroke-color="#000000" draw:fill-color="#99ccff" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.3cm" draw:shadow-offset-y="0.3cm" draw:start-line-spacing-horizontal="0.283cm" draw:start-line-spacing-vertical="0.283cm" draw:end-line-spacing-horizontal="0.283cm" draw:end-line-spacing-vertical="0.283cm" style:writing-mode="lr-tb" style:flow-with-text="false"/>
-   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0cm" style:font-independent-line-spacing="false">
+   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0cm" style:writing-mode="lr-tb" style:font-independent-line-spacing="false">
     <style:tab-stops/>
    </style:paragraph-properties>
    <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Times New Roman1" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="DejaVu Sans" style:font-size-asian="12pt" style:language-asian="zxx" style:country-asian="none" style:font-name-complex="Lucidasans1" style:font-size-complex="12pt" style:language-complex="zxx" style:country-complex="none"/>
@@ -997,15 +997,15 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:graphic-properties>
   </style:style>
   <style:style style:name="Frame" style:family="graphic">
-   <style:graphic-properties svg:width="17.189cm" fo:min-width="60%" svg:height="14.848cm" fo:min-height="56%" text:anchor-type="paragraph" svg:x="2.702cm" svg:y="0cm" fo:margin-left="0.508cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:run-through="foreground" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph-content" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" draw:fill="none" fo:padding="0.152cm" fo:border="0.06pt solid #000000" style:shadow="#000000 0.178cm 0.178cm" draw:shadow-opacity="100%" loext:rel-width-rel="paragraph" loext:rel-height-rel="paragraph">
+   <style:graphic-properties svg:width="17.189cm" fo:min-width="60%" svg:height="14.848cm" fo:min-height="56%" text:anchor-type="paragraph" svg:x="2.702cm" svg:y="0cm" fo:margin-left="0.508cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:run-through="foreground" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph-content" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" fo:background-color="transparent" draw:fill="none" fo:padding="0.152cm" fo:border="0.06pt solid #000000" style:shadow="#000000 0.178cm 0.178cm" draw:shadow-opacity="100%" loext:rel-width-rel="paragraph" loext:rel-height-rel="paragraph">
     <style:columns fo:column-count="1" fo:column-gap="0cm"/>
    </style:graphic-properties>
   </style:style>
   <style:style style:name="Formula" style:family="graphic">
-   <style:graphic-properties text:anchor-type="as-char" svg:y="0cm" fo:margin-left="0.051cm" fo:margin-right="0.051cm" style:wrap="parallel" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="middle" style:vertical-rel="text" draw:fill="none" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true"/>
+   <style:graphic-properties text:anchor-type="as-char" svg:y="0cm" fo:margin-left="0.051cm" fo:margin-right="0.051cm" style:wrap="parallel" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="middle" style:vertical-rel="text" fo:background-color="transparent" draw:fill="none" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true"/>
   </style:style>
   <style:style style:name="OLE" style:family="graphic">
-   <style:graphic-properties text:anchor-type="paragraph" svg:x="0cm" svg:y="0cm" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" draw:fill="none"/>
+   <style:graphic-properties text:anchor-type="paragraph" svg:x="0cm" svg:y="0cm" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" fo:background-color="transparent" draw:fill="none"/>
   </style:style>
   <text:outline-style style:name="Outline">
    <text:outline-level-style text:level="1" loext:num-list-format="CHAPTER %1%:" style:num-prefix="CHAPTER " style:num-suffix=":" style:num-format="1" text:start-value="12">
@@ -2683,10 +2683,72 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
   <style:style style:name="P22" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="00c150f8" officeooo:paragraph-rsid="00c150f8" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P23" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P24" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="01198236" officeooo:paragraph-rsid="01198236" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P25" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="011b2ab8" officeooo:paragraph-rsid="011b2ab8" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P26" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="small-caps" fo:color="#0066cc" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="16pt" fo:language="en" fo:country="US" fo:font-style="italic" officeooo:paragraph-rsid="002e95e7" style:font-name-asian="BernhardMod BT Roman" style:font-size-asian="16pt" style:font-style-asian="italic" style:font-name-complex="BernhardMod BT Roman" style:font-size-complex="16pt" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="P27" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="10.795cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="14pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="06f8892a" style:font-size-asian="14pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="14pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P28" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="16pt" fo:language="en" fo:country="US" fo:font-style="italic" officeooo:paragraph-rsid="002e95e7" style:font-name-asian="BernhardMod BT Roman" style:font-size-asian="16pt" style:font-style-asian="italic" style:font-name-complex="BernhardMod BT Roman" style:font-size-complex="16pt" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="P29" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="10.795cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Cabin" fo:font-size="14pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="14pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="14pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P30" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="10.795cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="12pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="12pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="12pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P31" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="12pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001a71eb" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="12pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="12pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P32" style:family="paragraph" style:parent-style-name="Standard">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:writing-mode="page"/>
    <style:text-properties fo:font-size="6pt" fo:language="en" fo:country="US" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="5.25pt" style:font-size-complex="6pt"/>
   </style:style>
-  <style:style style:name="P23" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
+  <style:style style:name="P33" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
    <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
     <style:tab-stops>
@@ -2696,91 +2758,32 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P24" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P34" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
    <style:text-properties fo:language="en" fo:country="US" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="00531151" officeooo:paragraph-rsid="062cbd9a" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
-  <style:style style:name="P25" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P35" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="00c1d7af" officeooo:paragraph-rsid="00e44d1e"/>
   </style:style>
-  <style:style style:name="P26" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="062e77b5"/>
-  </style:style>
-  <style:style style:name="P27" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="062cbd9a"/>
-  </style:style>
-  <style:style style:name="P28" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="17d7c939"/>
-  </style:style>
-  <style:style style:name="P29" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="069aba2a"/>
-  </style:style>
-  <style:style style:name="P30" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="1505b3fa"/>
-  </style:style>
-  <style:style style:name="P31" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="062e77b5"/>
-  </style:style>
-  <style:style style:name="P32" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="062cbd9a"/>
-  </style:style>
-  <style:style style:name="P33" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="06305dda"/>
-  </style:style>
-  <style:style style:name="P34" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="069aba2a"/>
-  </style:style>
-  <style:style style:name="P35" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="008b5b84"/>
-  </style:style>
   <style:style style:name="P36" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06349c75" officeooo:paragraph-rsid="06349c75"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="062e77b5"/>
   </style:style>
   <style:style style:name="P37" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06349c75" officeooo:paragraph-rsid="062cbd9a"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="062cbd9a"/>
   </style:style>
   <style:style style:name="P38" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06349c75" officeooo:paragraph-rsid="069b4f6d"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="17d7c939"/>
   </style:style>
   <style:style style:name="P39" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06372cf3" officeooo:paragraph-rsid="06372cf3"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="001c25db"/>
   </style:style>
   <style:style style:name="P40" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
@@ -2790,39 +2793,108 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      <style:tab-stop style:position="1.27cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06566c1a" officeooo:paragraph-rsid="069e3dba"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="069aba2a"/>
   </style:style>
   <style:style style:name="P41" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062cbd9a" officeooo:paragraph-rsid="06561bb9"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="1505b3fa"/>
   </style:style>
   <style:style style:name="P42" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062cbd9a" officeooo:paragraph-rsid="062cbd9a"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="062e77b5"/>
   </style:style>
   <style:style style:name="P43" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069aba2a" officeooo:paragraph-rsid="069aba2a"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="062cbd9a"/>
   </style:style>
   <style:style style:name="P44" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069aba2a" officeooo:paragraph-rsid="069aba2a"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="06305dda"/>
   </style:style>
   <style:style style:name="P45" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069aba2a" officeooo:paragraph-rsid="069aba2a"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="069aba2a"/>
   </style:style>
   <style:style style:name="P46" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="008b5b84"/>
+  </style:style>
+  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06349c75" officeooo:paragraph-rsid="06349c75"/>
+  </style:style>
+  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06349c75" officeooo:paragraph-rsid="062cbd9a"/>
+  </style:style>
+  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06349c75" officeooo:paragraph-rsid="069b4f6d"/>
+  </style:style>
+  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06372cf3" officeooo:paragraph-rsid="06372cf3"/>
+  </style:style>
+  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06566c1a" officeooo:paragraph-rsid="069e3dba"/>
+  </style:style>
+  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062cbd9a" officeooo:paragraph-rsid="06561bb9"/>
+  </style:style>
+  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062cbd9a" officeooo:paragraph-rsid="001c25db"/>
+  </style:style>
+  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062cbd9a" officeooo:paragraph-rsid="062cbd9a"/>
+  </style:style>
+  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069aba2a" officeooo:paragraph-rsid="069aba2a"/>
+  </style:style>
+  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069aba2a" officeooo:paragraph-rsid="069aba2a"/>
+  </style:style>
+  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069aba2a" officeooo:paragraph-rsid="069aba2a"/>
+  </style:style>
+  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069aba2a" officeooo:paragraph-rsid="069aba2a"/>
   </style:style>
-  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -2832,131 +2904,53 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069aba2a" officeooo:paragraph-rsid="069aba2a"/>
   </style:style>
-  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069b4f6d"/>
-  </style:style>
-  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069b4f6d"/>
-  </style:style>
-  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069b4f6d"/>
-  </style:style>
-  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069d277f"/>
-  </style:style>
-  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069b4f6d"/>
-  </style:style>
-  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="Footnote">
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069b4f6d"/>
-  </style:style>
-  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069d277f" officeooo:paragraph-rsid="069d277f"/>
-  </style:style>
-  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069d277f" officeooo:paragraph-rsid="069d277f"/>
-  </style:style>
-  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069d277f" officeooo:paragraph-rsid="069d277f"/>
-  </style:style>
-  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069d277f" officeooo:paragraph-rsid="069d277f"/>
-  </style:style>
-  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Footnote">
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069d277f" officeooo:paragraph-rsid="069d277f"/>
-  </style:style>
-  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="0769379e" officeooo:paragraph-rsid="069b4f6d"/>
-  </style:style>
   <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="07876263" officeooo:paragraph-rsid="07876263"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069b4f6d"/>
   </style:style>
   <style:style style:name="P61" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069e3dba" officeooo:paragraph-rsid="069e3dba"/>
+   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069b4f6d"/>
   </style:style>
   <style:style style:name="P62" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069e3dba" officeooo:paragraph-rsid="069e3dba"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069b4f6d"/>
   </style:style>
   <style:style style:name="P63" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069e3dba" officeooo:paragraph-rsid="069e3dba"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069d277f"/>
   </style:style>
   <style:style style:name="P64" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069e3dba" officeooo:paragraph-rsid="069e3dba"/>
-  </style:style>
-  <style:style style:name="P65" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="150512cf" officeooo:paragraph-rsid="150512cf"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069b4f6d"/>
+  </style:style>
+  <style:style style:name="P65" style:family="paragraph" style:parent-style-name="Footnote">
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069b4f6d"/>
   </style:style>
   <style:style style:name="P66" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="150512cf" officeooo:paragraph-rsid="069e3dba"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069d277f" officeooo:paragraph-rsid="069d277f"/>
   </style:style>
   <style:style style:name="P67" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="150512cf" officeooo:paragraph-rsid="150512cf"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069d277f" officeooo:paragraph-rsid="069d277f"/>
   </style:style>
   <style:style style:name="P68" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
@@ -2966,421 +2960,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      <style:tab-stop style:position="1.27cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="1505b3fa" officeooo:paragraph-rsid="1505b3fa"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069d277f" officeooo:paragraph-rsid="069d277f"/>
   </style:style>
   <style:style style:name="P69" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="19ebf62b" officeooo:paragraph-rsid="19ebf62b"/>
-  </style:style>
-  <style:style style:name="P70" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="17d7c939" officeooo:paragraph-rsid="17d7c939"/>
-  </style:style>
-  <style:style style:name="P71" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="1b7da751" officeooo:paragraph-rsid="1b7da751"/>
-  </style:style>
-  <style:style style:name="P72" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="004069ac" officeooo:paragraph-rsid="062cbd9a"/>
-  </style:style>
-  <style:style style:name="P73" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="05c34edf" officeooo:paragraph-rsid="062cbd9a"/>
-  </style:style>
-  <style:style style:name="P74" style:family="paragraph" style:parent-style-name="Table_20_Heading">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P75" style:family="paragraph" style:parent-style-name="_40_TextBody">
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="063c3886" officeooo:paragraph-rsid="063c3886"/>
-  </style:style>
-  <style:style style:name="P76" style:family="paragraph" style:parent-style-name="_40_Example">
-   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="069f4f78"/>
-  </style:style>
-  <style:style style:name="P77" style:family="paragraph" style:parent-style-name="_40_Example">
-   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="008d876e"/>
-  </style:style>
-  <style:style style:name="P78" style:family="paragraph" style:parent-style-name="_40_Example">
-   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069f4f78" officeooo:paragraph-rsid="069f4f78"/>
-  </style:style>
-  <style:style style:name="P79" style:family="paragraph" style:parent-style-name="_40_Example">
-   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069f4f78" officeooo:paragraph-rsid="008d876e"/>
-  </style:style>
-  <style:style style:name="P80" style:family="paragraph" style:parent-style-name="Table">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P81" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="00c4ec6d" officeooo:paragraph-rsid="062cbd9a"/>
-  </style:style>
-  <style:style style:name="P82" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="063da055"/>
-  </style:style>
-  <style:style style:name="P83" style:family="paragraph" style:parent-style-name="Heading_20_3">
-   <style:paragraph-properties fo:break-before="page"/>
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P84" style:family="paragraph" style:parent-style-name="Heading_20_4">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P85" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="justify" style:justify-single-word="false"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="05c7f16b" officeooo:paragraph-rsid="069f4f78"/>
-  </style:style>
-  <style:style style:name="P86" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06305dda" officeooo:paragraph-rsid="069aba2a"/>
-  </style:style>
-  <style:style style:name="P87" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06305dda" officeooo:paragraph-rsid="069b4f6d"/>
-  </style:style>
-  <style:style style:name="P88" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="066fc5c7" officeooo:paragraph-rsid="069aba2a"/>
-  </style:style>
-  <style:style style:name="P89" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="069d277f"/>
-  </style:style>
-  <style:style style:name="P90" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="069e3dba"/>
-  </style:style>
-  <style:style style:name="P91" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06608a53" officeooo:paragraph-rsid="069b4f6d"/>
-  </style:style>
-  <style:style style:name="P92" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06608a53" officeooo:paragraph-rsid="069d277f"/>
-  </style:style>
-  <style:style style:name="P93" style:family="paragraph" style:parent-style-name="Footer">
-   <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
-    <style:tab-stops>
-     <style:tab-stop style:position="8.498cm" style:type="center"/>
-     <style:tab-stop style:position="16.999cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="07061c8d" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P94" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
-    <style:tab-stops>
-     <style:tab-stop style:position="8.498cm" style:type="center"/>
-     <style:tab-stop style:position="16.999cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P95" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="00c150f8" officeooo:paragraph-rsid="00c150f8" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P96" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P97" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="01198236" officeooo:paragraph-rsid="01198236" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P98" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="011b2ab8" officeooo:paragraph-rsid="011b2ab8" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P99" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops>
-     <style:tab-stop style:position="10.795cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="12pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="12pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="12pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P100" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="12pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001a71eb" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="12pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="12pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P101" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops>
-     <style:tab-stop style:position="10.795cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="14pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="06f8892a" style:font-size-asian="14pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="14pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P102" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="16pt" fo:language="en" fo:country="US" fo:font-style="italic" officeooo:paragraph-rsid="002e95e7" style:font-name-asian="BernhardMod BT Roman" style:font-size-asian="16pt" style:font-style-asian="italic" style:font-name-complex="BernhardMod BT Roman" style:font-size-complex="16pt" style:font-style-complex="italic"/>
-  </style:style>
-  <style:style style:name="P103" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops>
-     <style:tab-stop style:position="10.795cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Cabin" fo:font-size="14pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="14pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="14pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P104" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="small-caps" fo:color="#0066cc" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="16pt" fo:language="en" fo:country="US" fo:font-style="italic" officeooo:paragraph-rsid="002e95e7" style:font-name-asian="BernhardMod BT Roman" style:font-size-asian="16pt" style:font-style-asian="italic" style:font-name-complex="BernhardMod BT Roman" style:font-size-complex="16pt" style:font-style-complex="italic"/>
-  </style:style>
-  <style:style style:name="P105" style:family="paragraph" style:parent-style-name="_40_Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties officeooo:paragraph-rsid="14d36d55"/>
-  </style:style>
-  <style:style style:name="P106" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
-  </style:style>
-  <style:style style:name="P107" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" officeooo:rsid="0117c15b" officeooo:paragraph-rsid="0117c15b" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P108" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P109" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" officeooo:paragraph-rsid="13ac3201" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P110" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P111" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" fo:language="en" fo:country="US" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P112" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties officeooo:rsid="003d1478" officeooo:paragraph-rsid="0123e63b"/>
-  </style:style>
-  <style:style style:name="P113" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="0125229e"/>
-  </style:style>
-  <style:style style:name="P114" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="0128289a"/>
-  </style:style>
-  <style:style style:name="P115" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="01299126"/>
-  </style:style>
-  <style:style style:name="P116" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="012c7fe1"/>
-  </style:style>
-  <style:style style:name="P117" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="012573d0"/>
-  </style:style>
-  <style:style style:name="P118" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-size="9pt" fo:language="en" fo:country="US" officeooo:rsid="0656caca" officeooo:paragraph-rsid="069d277f" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P119" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-size="9pt" fo:language="en" fo:country="US" officeooo:rsid="069e3dba" officeooo:paragraph-rsid="069e3dba" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P120" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:font-size="9pt" fo:language="en" fo:country="US" officeooo:rsid="069479d0" officeooo:paragraph-rsid="069d277f" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P121" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Gill Sans MT3" fo:font-size="9pt" fo:language="en" fo:country="US" fo:font-weight="normal" officeooo:rsid="150512cf" officeooo:paragraph-rsid="150512cf" fo:background-color="transparent" style:font-name-asian="Times New Roman" style:font-size-asian="10pt" style:font-weight-asian="bold" style:font-name-complex="Times New Roman" style:font-size-complex="10pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P122" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <style:paragraph-properties style:page-number="auto"/>
-  </style:style>
-  <style:style style:name="P123" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="justify" style:justify-single-word="false"/>
-   <style:text-properties style:text-position="0% 100%" fo:language="en" fo:country="US" officeooo:rsid="069f4f78" officeooo:paragraph-rsid="069f4f78"/>
-  </style:style>
-  <style:style style:name="P124" style:family="paragraph" style:parent-style-name="Heading_20_3">
-   <style:paragraph-properties fo:break-before="page"/>
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P125" style:family="paragraph" style:parent-style-name="Heading_20_4">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P126" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="First_20_Page">
-   <style:paragraph-properties style:page-number="auto"/>
-  </style:style>
-  <style:style style:name="P127" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06305dda" officeooo:paragraph-rsid="069aba2a"/>
-  </style:style>
-  <style:style style:name="P128" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06305dda" officeooo:paragraph-rsid="069b4f6d"/>
-  </style:style>
-  <style:style style:name="P129" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="066fc5c7" officeooo:paragraph-rsid="069aba2a"/>
-  </style:style>
-  <style:style style:name="P130" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069aba2a" officeooo:paragraph-rsid="069aba2a"/>
-  </style:style>
-  <style:style style:name="P131" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069b4f6d" officeooo:paragraph-rsid="069b4f6d"/>
-  </style:style>
-  <style:style style:name="P132" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06608a53" officeooo:paragraph-rsid="069b4f6d"/>
-  </style:style>
-  <style:style style:name="P133" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06608a53" officeooo:paragraph-rsid="069d277f"/>
-  </style:style>
-  <style:style style:name="P134" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="069d277f"/>
-  </style:style>
-  <style:style style:name="P135" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="0.961cm"/>
-     <style:tab-stop style:position="1.27cm"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="069e3dba"/>
-  </style:style>
-  <style:style style:name="P136" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -3390,7 +2972,40 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069d277f" officeooo:paragraph-rsid="069d277f"/>
   </style:style>
-  <style:style style:name="P137" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
+  <style:style style:name="P70" style:family="paragraph" style:parent-style-name="Footnote">
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069d277f" officeooo:paragraph-rsid="069d277f"/>
+  </style:style>
+  <style:style style:name="P71" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="0769379e" officeooo:paragraph-rsid="069b4f6d"/>
+  </style:style>
+  <style:style style:name="P72" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="07876263" officeooo:paragraph-rsid="07876263"/>
+  </style:style>
+  <style:style style:name="P73" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069e3dba" officeooo:paragraph-rsid="069e3dba"/>
+  </style:style>
+  <style:style style:name="P74" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069e3dba" officeooo:paragraph-rsid="069e3dba"/>
+  </style:style>
+  <style:style style:name="P75" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069e3dba" officeooo:paragraph-rsid="069e3dba"/>
+  </style:style>
+  <style:style style:name="P76" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -3400,33 +3015,327 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069e3dba" officeooo:paragraph-rsid="069e3dba"/>
   </style:style>
-  <style:style style:name="P138" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="L1">
-   <style:paragraph-properties fo:text-align="justify" style:justify-single-word="false"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="05c7f16b" officeooo:paragraph-rsid="069f4f78"/>
+  <style:style style:name="P77" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="150512cf" officeooo:paragraph-rsid="150512cf"/>
   </style:style>
-  <style:style style:name="P139" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P78" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="1b7da751" officeooo:paragraph-rsid="001c25db"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="150512cf" officeooo:paragraph-rsid="069e3dba"/>
   </style:style>
-  <style:style style:name="P140" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P79" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="001c25db"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="150512cf" officeooo:paragraph-rsid="150512cf"/>
   </style:style>
-  <style:style style:name="P141" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P80" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="1505b3fa" officeooo:paragraph-rsid="1505b3fa"/>
+  </style:style>
+  <style:style style:name="P81" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="19ebf62b" officeooo:paragraph-rsid="19ebf62b"/>
+  </style:style>
+  <style:style style:name="P82" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062cbd9a" officeooo:paragraph-rsid="001c25db"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="17d7c939" officeooo:paragraph-rsid="17d7c939"/>
   </style:style>
-  <style:style style:name="P142" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P83" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="17d7c939" officeooo:paragraph-rsid="001c25db"/>
   </style:style>
-  <style:style style:name="P143" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="L1">
+  <style:style style:name="P84" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="1b7da751" officeooo:paragraph-rsid="1b7da751"/>
+  </style:style>
+  <style:style style:name="P85" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="1b7da751" officeooo:paragraph-rsid="001c25db"/>
+  </style:style>
+  <style:style style:name="P86" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="004069ac" officeooo:paragraph-rsid="062cbd9a"/>
+  </style:style>
+  <style:style style:name="P87" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="05c34edf" officeooo:paragraph-rsid="062cbd9a"/>
+  </style:style>
+  <style:style style:name="P88" style:family="paragraph" style:parent-style-name="Table_20_Heading">
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P89" style:family="paragraph" style:parent-style-name="_40_TextBody">
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="063c3886" officeooo:paragraph-rsid="063c3886"/>
+  </style:style>
+  <style:style style:name="P90" style:family="paragraph" style:parent-style-name="_40_Example">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="069f4f78"/>
+  </style:style>
+  <style:style style:name="P91" style:family="paragraph" style:parent-style-name="_40_Example">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="008d876e"/>
+  </style:style>
+  <style:style style:name="P92" style:family="paragraph" style:parent-style-name="_40_Example">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069f4f78" officeooo:paragraph-rsid="069f4f78"/>
+  </style:style>
+  <style:style style:name="P93" style:family="paragraph" style:parent-style-name="_40_Example">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="069f4f78" officeooo:paragraph-rsid="008d876e"/>
+  </style:style>
+  <style:style style:name="P94" style:family="paragraph" style:parent-style-name="Table">
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P95" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="00c4ec6d" officeooo:paragraph-rsid="062cbd9a"/>
+  </style:style>
+  <style:style style:name="P96" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="063da055"/>
+  </style:style>
+  <style:style style:name="P97" style:family="paragraph" style:parent-style-name="Heading_20_3">
+   <style:paragraph-properties fo:break-before="page"/>
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P98" style:family="paragraph" style:parent-style-name="Heading_20_4">
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P99" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="justify" style:justify-single-word="false"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="05c7f16b" officeooo:paragraph-rsid="069f4f78"/>
+  </style:style>
+  <style:style style:name="P100" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06305dda" officeooo:paragraph-rsid="069aba2a"/>
+  </style:style>
+  <style:style style:name="P101" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06305dda" officeooo:paragraph-rsid="069b4f6d"/>
+  </style:style>
+  <style:style style:name="P102" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="066fc5c7" officeooo:paragraph-rsid="069aba2a"/>
+  </style:style>
+  <style:style style:name="P103" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="069d277f"/>
+  </style:style>
+  <style:style style:name="P104" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="069e3dba"/>
+  </style:style>
+  <style:style style:name="P105" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06608a53" officeooo:paragraph-rsid="069b4f6d"/>
+  </style:style>
+  <style:style style:name="P106" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06608a53" officeooo:paragraph-rsid="069d277f"/>
+  </style:style>
+  <style:style style:name="P107" style:family="paragraph" style:parent-style-name="_40_Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties officeooo:paragraph-rsid="14d36d55"/>
+  </style:style>
+  <style:style style:name="P108" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+  </style:style>
+  <style:style style:name="P109" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" officeooo:rsid="0117c15b" officeooo:paragraph-rsid="0117c15b" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P110" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P111" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" officeooo:paragraph-rsid="13ac3201" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P112" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P113" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" fo:language="en" fo:country="US" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P114" style:family="paragraph" style:parent-style-name="Footer">
+   <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
+    <style:tab-stops>
+     <style:tab-stop style:position="8.498cm" style:type="center"/>
+     <style:tab-stop style:position="16.999cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="07061c8d" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P115" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
+    <style:tab-stops>
+     <style:tab-stop style:position="8.498cm" style:type="center"/>
+     <style:tab-stop style:position="16.999cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P116" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties officeooo:rsid="003d1478" officeooo:paragraph-rsid="0123e63b"/>
+  </style:style>
+  <style:style style:name="P117" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="0125229e"/>
+  </style:style>
+  <style:style style:name="P118" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="0128289a"/>
+  </style:style>
+  <style:style style:name="P119" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="01299126"/>
+  </style:style>
+  <style:style style:name="P120" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="012c7fe1"/>
+  </style:style>
+  <style:style style:name="P121" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="012573d0"/>
+  </style:style>
+  <style:style style:name="P122" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-size="9pt" fo:language="en" fo:country="US" officeooo:rsid="0656caca" officeooo:paragraph-rsid="069d277f" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P123" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-size="9pt" fo:language="en" fo:country="US" officeooo:rsid="069e3dba" officeooo:paragraph-rsid="069e3dba" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P124" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:font-size="9pt" fo:language="en" fo:country="US" officeooo:rsid="069479d0" officeooo:paragraph-rsid="069d277f" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P125" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Gill Sans MT3" fo:font-size="9pt" fo:language="en" fo:country="US" fo:font-weight="normal" officeooo:rsid="150512cf" officeooo:paragraph-rsid="150512cf" fo:background-color="transparent" style:font-name-asian="Times New Roman" style:font-size-asian="10pt" style:font-weight-asian="bold" style:font-name-complex="Times New Roman" style:font-size-complex="10pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P126" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <style:paragraph-properties style:page-number="auto"/>
+  </style:style>
+  <style:style style:name="P127" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="justify" style:justify-single-word="false"/>
    <style:text-properties style:text-position="0% 100%" fo:language="en" fo:country="US" officeooo:rsid="069f4f78" officeooo:paragraph-rsid="069f4f78"/>
+  </style:style>
+  <style:style style:name="P128" style:family="paragraph" style:parent-style-name="_40_Example">
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P129" style:family="paragraph" style:parent-style-name="_40_TextBody">
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P130" style:family="paragraph" style:parent-style-name="Heading_20_3">
+   <style:paragraph-properties fo:break-before="page"/>
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P131" style:family="paragraph" style:parent-style-name="Heading_20_4">
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P132" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="First_20_Page">
+   <style:paragraph-properties style:page-number="auto"/>
+  </style:style>
+  <style:style style:name="P133" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P134" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P135" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P136" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P137" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
+   <style:paragraph-properties style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="P138" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="L1">
+   <style:text-properties fo:language="en" fo:country="US"/>
   </style:style>
   <style:style style:name="T1" style:family="text">
    <style:text-properties fo:font-size="20pt" style:font-size-asian="20pt" style:font-size-complex="20pt"/>
@@ -3456,25 +3365,25 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <style:text-properties style:font-name="Gill Sans MT" officeooo:rsid="06f4e628"/>
   </style:style>
   <style:style style:name="T10" style:family="text">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="T11" style:family="text">
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="13ac3201"/>
-  </style:style>
-  <style:style style:name="T12" style:family="text">
    <style:text-properties fo:font-size="20pt" style:font-size-asian="20pt" style:font-size-complex="20pt"/>
   </style:style>
-  <style:style style:name="T13" style:family="text">
+  <style:style style:name="T11" style:family="text">
    <style:text-properties fo:font-size="20pt" fo:font-style="normal" style:font-size-asian="20pt" style:font-style-asian="normal" style:font-size-complex="20pt" style:font-style-complex="normal"/>
   </style:style>
-  <style:style style:name="T14" style:family="text">
+  <style:style style:name="T12" style:family="text">
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="20pt" fo:font-style="normal" style:font-size-asian="20pt" style:font-style-asian="normal" style:font-size-complex="20pt" style:font-style-complex="normal"/>
   </style:style>
-  <style:style style:name="T15" style:family="text">
+  <style:style style:name="T13" style:family="text">
    <style:text-properties officeooo:rsid="06f4e628"/>
   </style:style>
-  <style:style style:name="T16" style:family="text">
+  <style:style style:name="T14" style:family="text">
    <style:text-properties officeooo:rsid="07070fd2"/>
+  </style:style>
+  <style:style style:name="T15" style:family="text">
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="T16" style:family="text">
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="13ac3201"/>
   </style:style>
   <style:style style:name="T17" style:family="text">
    <style:text-properties style:font-name="Gill Sans MT"/>
@@ -5024,9 +4933,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:user-field-decl office:value-type="float" office:value="1" text:name="MD"/>
     <text:user-field-decl office:value-type="string" office:string-value="" text:name="SEQ CHAPTER \h   1"/>
    </text:user-field-decls>
-   <text:p text:style-name="P126"/>
+   <text:p text:style-name="P132"/>
    <text:section text:style-name="Sect1" text:name="WELSPECS">
-    <text:h text:style-name="P83" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc268463_1366622701"/>WELSPECS – Define Well Specifications<text:bookmark-end text:name="__RefHeading___Toc268463_1366622701"/></text:h>
+    <text:h text:style-name="P97" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc268463_1366622701"/>WELSPECS – Define Well Specifications<text:bookmark-end text:name="__RefHeading___Toc268463_1366622701"/></text:h>
     <table:table table:name="Table135" table:style-name="Table135">
      <table:table-column table:style-name="Table135.A" table:number-columns-repeated="4"/>
      <table:table-column table:style-name="Table135.E"/>
@@ -5034,33 +4943,33 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      <table:table-column table:style-name="Table135.A" table:number-columns-repeated="2"/>
      <table:table-row>
       <table:table-cell table:style-name="Table135.A1" office:value-type="string">
-       <text:p text:style-name="P112"><text:a xlink:type="simple" xlink:href="#3.RUNSPEC SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">RUNSPEC</text:span></text:a></text:p>
+       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#3.RUNSPEC SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">RUNSPEC</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table135.A1" office:value-type="string">
-       <text:p text:style-name="P113"><text:a xlink:type="simple" xlink:href="#4.GRID SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">GRID</text:span></text:a></text:p>
+       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#4.GRID SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">GRID</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table135.A1" office:value-type="string">
-       <text:p text:style-name="P117"><text:a xlink:type="simple" xlink:href="#5.EDIT SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">EDIT</text:span></text:a></text:p>
+       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#5.EDIT SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">EDIT</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table135.A1" office:value-type="string">
-       <text:p text:style-name="P114"><text:a xlink:type="simple" xlink:href="#6.PROPS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">PROPS</text:span></text:a></text:p>
+       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#6.PROPS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">PROPS</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table135.A1" office:value-type="string">
-       <text:p text:style-name="P114"><text:a xlink:type="simple" xlink:href="#7.REGIONS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">REGIONS</text:span></text:a></text:p>
+       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#7.REGIONS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">REGIONS</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table135.A1" office:value-type="string">
-       <text:p text:style-name="P115"><text:a xlink:type="simple" xlink:href="#8.SOLUTION SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SOLUTION</text:span></text:a></text:p>
+       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#8.SOLUTION SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SOLUTION</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table135.A1" office:value-type="string">
-       <text:p text:style-name="P115"><text:a xlink:type="simple" xlink:href="#9.SUMMARY SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SUMMARY</text:span></text:a></text:p>
+       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#9.SUMMARY SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SUMMARY</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table135.H1" office:value-type="string">
-       <text:p text:style-name="P116"><text:a xlink:type="simple" xlink:href="#10.SCHEDULE SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SCHEDULE</text:span></text:a></text:p>
+       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#10.SCHEDULE SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SCHEDULE</text:span></text:a></text:p>
       </table:table-cell>
      </table:table-row>
     </table:table>
-    <text:h text:style-name="P84" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc716753_3964674244"/>Description<text:bookmark-end text:name="__RefHeading___Toc716753_3964674244"/></text:h>
-    <text:p text:style-name="_40_TextBody">The <text:span text:style-name="T28">WELSPECS</text:span> keyword defines <text:span text:style-name="T28">the general </text:span>well <text:span text:style-name="T28">specification data for all well types, and must be used for all wells before any other well specification keywords are used in the input file. The keyword declares the well, the name of the well, the group the well initial belongs to, the wellhead location and other key parameters.</text:span></text:p>
+    <text:h text:style-name="P98" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc716753_3964674244"/>Description<text:bookmark-end text:name="__RefHeading___Toc716753_3964674244"/></text:h>
+    <text:p text:style-name="_40_TextBody">The WELSPECS keyword defines the general well specification data for all well types, and must be used for all wells before any other well specification keywords are used in the input file. The keyword declares the well, the name of the well, the group the well initial belongs to, the wellhead location and other key parameters.</text:p>
     <table:table table:name="Table665" table:style-name="Table665">
      <table:table-column table:style-name="Table665.A"/>
      <table:table-column table:style-name="Table665.B"/>
@@ -5070,345 +4979,345 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      <table:table-header-rows>
       <table:table-row table:style-name="Table665.1">
        <table:table-cell table:style-name="Table665.A1" table:number-rows-spanned="2" office:value-type="string">
-        <text:p text:style-name="P74">No.</text:p>
+        <text:p text:style-name="P88">No.</text:p>
        </table:table-cell>
        <table:table-cell table:style-name="Table665.A1" table:number-rows-spanned="2" office:value-type="string">
-        <text:p text:style-name="P74">Name</text:p>
+        <text:p text:style-name="P88">Name</text:p>
        </table:table-cell>
        <table:table-cell table:style-name="Table665.A1" table:number-columns-spanned="3" office:value-type="string">
-        <text:p text:style-name="P74">Description</text:p>
+        <text:p text:style-name="P88">Description</text:p>
        </table:table-cell>
        <table:covered-table-cell/>
        <table:covered-table-cell/>
        <table:table-cell table:style-name="Table665.F1" table:number-rows-spanned="2" office:value-type="string">
-        <text:p text:style-name="P74">Default</text:p>
+        <text:p text:style-name="P88">Default</text:p>
        </table:table-cell>
       </table:table-row>
       <table:table-row table:style-name="Table665.1">
        <table:covered-table-cell table:style-name="Table665.A1"/>
        <table:covered-table-cell table:style-name="Table665.A1"/>
        <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-        <text:p text:style-name="P74">Field</text:p>
+        <text:p text:style-name="P88">Field</text:p>
        </table:table-cell>
        <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-        <text:p text:style-name="P74">Metric</text:p>
+        <text:p text:style-name="P88">Metric</text:p>
        </table:table-cell>
        <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-        <text:p text:style-name="P74">Laboratory</text:p>
+        <text:p text:style-name="P88">Laboratory</text:p>
        </table:table-cell>
        <table:covered-table-cell table:style-name="Table665.F1"/>
       </table:table-row>
      </table:table-header-rows>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P72">1</text:p>
+       <text:p text:style-name="P135">1</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P42">WELNAME</text:p>
+       <text:p text:style-name="P135">WELNAME</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P27">A character string of up to eight characters in length that defines the well name for which the well <text:span text:style-name="T59">specification</text:span> data is being defined.</text:p>
+       <text:p text:style-name="P135">A character string of up to eight characters in length that defines the well name for which the well specification data is being defined.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" office:value-type="string">
-       <text:p text:style-name="P26">None</text:p>
+       <text:p text:style-name="P136">None</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P43">2</text:p>
+       <text:p text:style-name="P135">2</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P42"><text:span text:style-name="T37">GRP</text:span>NAME</text:p>
+       <text:p text:style-name="P135">GRPNAME</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P140">A character string of up to eight characters in length that defines the <text:span text:style-name="T37">group</text:span> name for which the <text:span text:style-name="T28">well is assigned to. </text:span></text:p>
-       <text:p text:style-name="P140"><text:span text:style-name="T28">The group named FIELD is the top most group. </text:span><text:span text:style-name="T55">GRPNAME </text:span><text:span text:style-name="T62">can</text:span><text:span text:style-name="T55"> be set to FIELD </text:span><text:span text:style-name="T62">although this is discouraged and a warning message will be issued.</text:span><text:span text:style-name="T55"> </text:span><text:span text:style-name="T62">T</text:span><text:span text:style-name="T55">his is allowed in the commercial </text:span><text:span text:style-name="T25">compositional</text:span><text:span text:style-name="T55"> simulator but not the </text:span><text:span text:style-name="T25">commercial</text:span><text:span text:style-name="T55"> black-oil simulator. </text:span><text:span text:style-name="T62">The FIELD group cannot contain both groups and wells.</text:span></text:p>
-       <text:p text:style-name="P141">Note that the <text:span text:style-name="T37">group</text:span> <text:span text:style-name="T39">hierarchy</text:span> <text:span text:style-name="T39">should be defined by the GRUPTREE keyword when there is more than one level of groups, otherwise all the groups will sit directly under the FIELD group in the group tree hierarchy</text:span>.</text:p>
-       <text:p text:style-name="P142">Secondly, groups defined by the GRUPTREE keyword cannot contain other groups <text:span text:style-name="T26">and</text:span> wells; that is, groups must either contain other groups or wells but not both.</text:p>
-       <text:p text:style-name="P139">If necessary, wells can be re-allocated to a different group by re-entering a well&apos;s WELSPECS data together with a new value for GRPNAME. </text:p>
+       <text:p text:style-name="P135">A character string of up to eight characters in length that defines the group name for which the well is assigned to. </text:p>
+       <text:p text:style-name="P135">The group named FIELD is the top most group. GRPNAME can be set to FIELD although this is discouraged and a warning message will be issued. This is allowed in the commercial compositional simulator but not the commercial black-oil simulator. The FIELD group cannot contain both groups and wells.</text:p>
+       <text:p text:style-name="P135">Note that the group hierarchy should be defined by the GRUPTREE keyword when there is more than one level of groups, otherwise all the groups will sit directly under the FIELD group in the group tree hierarchy.</text:p>
+       <text:p text:style-name="P135">Secondly, groups defined by the GRUPTREE keyword cannot contain other groups and wells; that is, groups must either contain other groups or wells but not both.</text:p>
+       <text:p text:style-name="P135">If necessary, wells can be re-allocated to a different group by re-entering a well&apos;s WELSPECS data together with a new value for GRPNAME. </text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" office:value-type="string">
-       <text:p text:style-name="P26">None</text:p>
+       <text:p text:style-name="P136">None</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P43">3</text:p>
+       <text:p text:style-name="P135">3</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P31">I</text:p>
+       <text:p text:style-name="P135">I</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P32">A positive integer greater than or equal to zero and less than or equal to NX that defines the <text:span text:style-name="T28">wellhead location for a vertical or deviated well, or the heel for a horizontal well</text:span> in the I-direction.</text:p>
-       <text:p text:style-name="P35"><text:span text:style-name="T60">For wells being specified with the COMPTRAJ and </text:span>WELTRAJ keyword<text:span text:style-name="T60">s in SCHEDULE section,</text:span> <text:span text:style-name="T60">that allow for an alternative manner</text:span> to define the well connections to the simulation grid blocks<text:span text:style-name="T60">,</text:span> <text:span text:style-name="T60">this parameter should be defaulted with 1*. Since the simulator will calculate the wellhead location from the trajectory data on the WELTRAJ keyword. </text:span></text:p>
-       <text:p text:style-name="P35"><text:span text:style-name="T60">Note that the COMPTRAJ and </text:span>WELTRAJ keyword<text:span text:style-name="T60">s are OPM Flow specific keywords, and will cause an error in the commercial simulator.</text:span></text:p>
+       <text:p text:style-name="P135">A positive integer greater than or equal to zero and less than or equal to NX that defines the wellhead location for a vertical or deviated well, or the heel for a horizontal well in the I-direction.</text:p>
+       <text:p text:style-name="P135">For wells being specified with the COMPTRAJ and WELTRAJ keywords in SCHEDULE section, that allow for an alternative manner to define the well connections to the simulation grid blocks, this parameter should be defaulted with 1*. Since the simulator will calculate the wellhead location from the trajectory data on the WELTRAJ keyword. </text:p>
+       <text:p text:style-name="P135">Note that the COMPTRAJ and WELTRAJ keywords are OPM Flow specific keywords, and will cause an error in the commercial simulator.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" office:value-type="string">
-       <text:p text:style-name="P43">None</text:p>
+       <text:p text:style-name="P135">None</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P44">4</text:p>
+       <text:p text:style-name="P135">4</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P31">J</text:p>
-       <text:p text:style-name="P73"/>
+       <text:p text:style-name="P135">J</text:p>
+       <text:p text:style-name="P135"/>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P34">A positive integer greater than or equal to zero and less than or equal to NY that defines the <text:span text:style-name="T28">wellhead location for a vertical or deviated well, or the heel for a horizontal well</text:span> in the <text:span text:style-name="T28">J</text:span>-direction.</text:p>
-       <text:p text:style-name="P35"><text:span text:style-name="T60">For wells being specified with the COMPTRAJ and </text:span>WELTRAJ keyword<text:span text:style-name="T60">s in SCHEDULE section,</text:span> <text:span text:style-name="T60">that allows for an alternative manner</text:span> to define the well connections to the simulation grid blocks<text:span text:style-name="T60">,</text:span> <text:span text:style-name="T60"><text:s/>this parameter should be defaulted with 1*. Since the simulator will calculate the wellhead location from the trajectory data on the WELTRAJ keyword. </text:span></text:p>
-       <text:p text:style-name="P35"><text:span text:style-name="T60">Note that the COMPTRAJ and </text:span>WELTRAJ keyword<text:span text:style-name="T60">s are OPM Flow specific keywords, and will cause an error in the commercial simulator.</text:span></text:p>
+       <text:p text:style-name="P135">A positive integer greater than or equal to zero and less than or equal to NY that defines the wellhead location for a vertical or deviated well, or the heel for a horizontal well in the J-direction.</text:p>
+       <text:p text:style-name="P135">For wells being specified with the COMPTRAJ and WELTRAJ keywords in SCHEDULE section, that allows for an alternative manner to define the well connections to the simulation grid blocks, <text:s/>this parameter should be defaulted with 1*. Since the simulator will calculate the wellhead location from the trajectory data on the WELTRAJ keyword. </text:p>
+       <text:p text:style-name="P135">Note that the COMPTRAJ and WELTRAJ keywords are OPM Flow specific keywords, and will cause an error in the commercial simulator.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" office:value-type="string">
-       <text:p text:style-name="P43">None</text:p>
+       <text:p text:style-name="P135">None</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P39">5</text:p>
+       <text:p text:style-name="P135">5</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P46">BHP<text:span text:style-name="T48">REF</text:span></text:p>
+       <text:p text:style-name="P135">BHPREF</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P33">A <text:span text:style-name="T28">real</text:span> <text:span text:style-name="T28">value that defines the reference depth for reporting the bottom-hole pressure for the well</text:span>. <text:span text:style-name="T28">Ideally this value should be set to the midpoint of the perforations as defined by the COMPDAT keyword in the SCHEDULE section.</text:span></text:p>
-       <text:p text:style-name="P45">If defaulted by 1* or set to a value less than or equal to zero, then the mid-point of shallowest connection defined by the COMPDAT keyword will be used.</text:p>
+       <text:p text:style-name="P135">A real value that defines the reference depth for reporting the bottom-hole pressure for the well. Ideally this value should be set to the midpoint of the perforations as defined by the COMPDAT keyword in the SCHEDULE section.</text:p>
+       <text:p text:style-name="P135">If defaulted by 1* or set to a value less than or equal to zero, then the mid-point of shallowest connection defined by the COMPDAT keyword will be used.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P43">Mid-point of shallowest connection defined by the COMPDAT keyword</text:p>
+       <text:p text:style-name="P135">Mid-point of shallowest connection defined by the COMPDAT keyword</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:covered-table-cell table:style-name="Table665.C2"/>
       <table:covered-table-cell table:style-name="Table665.C2"/>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P25"><text:span text:style-name="T36">f</text:span>eet</text:p>
+       <text:p text:style-name="P136">feet</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P36">m</text:p>
+       <text:p text:style-name="P136">m</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.E8" office:value-type="string">
-       <text:p text:style-name="P25">cm</text:p>
+       <text:p text:style-name="P136">cm</text:p>
       </table:table-cell>
       <table:covered-table-cell table:style-name="Table665.F3"/>
      </table:table-row>
      <text:soft-page-break/>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P39">6</text:p>
+       <text:p text:style-name="P135">6</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P45">TYPE</text:p>
+       <text:p text:style-name="P135">TYPE</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P29">A <text:span text:style-name="T28">defined character </text:span><text:span text:style-name="T57">string t</text:span><text:span text:style-name="T28">hat defines the “main” phase for the well, and should be </text:span>set to one of the following character strings:</text:p>
+       <text:p text:style-name="P135">A defined character string that defines the “main” phase for the well, and should be set to one of the following character strings:</text:p>
        <text:list text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P127"><text:span text:style-name="T42">GAS</text:span>: <text:span text:style-name="T42">for a gas well. </text:span></text:p>
+         <text:p text:style-name="P137">GAS: for a gas well. </text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P129">OIL: for a<text:span text:style-name="T28">n</text:span> <text:span text:style-name="T28">oil</text:span> well. </text:p>
+         <text:p text:style-name="P137">OIL: for an oil well. </text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P129">WAT: for a water injection well. </text:p>
+         <text:p text:style-name="P137">WAT: for a water injection well. </text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P130">LIQ: for a<text:span text:style-name="T50">n</text:span> oil well when the liquid productivity index is required for the well.</text:p>
+         <text:p text:style-name="P137">LIQ: for an oil well when the liquid productivity index is required for the well.</text:p>
         </text:list-item>
        </text:list>
-       <text:p text:style-name="P48">This parameter defines the phase used to calculate a well’s productivity or injectivity index and the type of well, or a well’s connection, to close when a group’s production constraints, as defined on the GCONPROD keyword in the SCHEDULE section, have been violated. For example, if the well is declared as an oil well, then excessive gas and water connections will be subject to closure.</text:p>
-       <text:p text:style-name="P69">Note OPM Flow only currently supports options one to three, that is option <text:span text:style-name="T56">four (</text:span>LIQ<text:span text:style-name="T56">)</text:span> is <text:span text:style-name="T26">not</text:span> supported. <text:s/>For producing wells this mostly matters if <text:span text:style-name="T56">one</text:span> plot<text:span text:style-name="T56">s</text:span> the WPI summary vector (productivity index for well&apos;s preferred phase). In the current treatment WPI will not have contributions from the water phase if the declared preferred phase is LIQ. For injecting wells WELSPECS&apos;s preferred phase does n<text:span text:style-name="T56">o</text:span>t matter, <text:s/>since the preferred phase is (typically) reset to the injected phase <text:span text:style-name="T56">via the </text:span>WCONINJE <text:span text:style-name="T56">and </text:span>WCONINJH <text:span text:style-name="T56">keywords</text:span>.</text:p>
+       <text:p text:style-name="P135">This parameter defines the phase used to calculate a well’s productivity or injectivity index and the type of well, or a well’s connection, to close when a group’s production constraints, as defined on the GCONPROD keyword in the SCHEDULE section, have been violated. For example, if the well is declared as an oil well, then excessive gas and water connections will be subject to closure.</text:p>
+       <text:p text:style-name="P135">Note OPM Flow only currently supports options one to three, that is option four (LIQ) is not supported. <text:s/>For producing wells this mostly matters if one plots the WPI summary vector (productivity index for well&apos;s preferred phase). In the current treatment WPI will not have contributions from the water phase if the declared preferred phase is LIQ. For injecting wells WELSPECS&apos;s preferred phase does not matter, <text:s/>since the preferred phase is (typically) reset to the injected phase via the WCONINJE and WCONINJH keywords.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" office:value-type="string">
-       <text:p text:style-name="P54">None</text:p>
+       <text:p text:style-name="P135">None</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P52">7</text:p>
+       <text:p text:style-name="P135">7</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P59">DRADIUS</text:p>
+       <text:p text:style-name="P135">DRADIUS</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P37">A real value that defines the well drainage <text:span text:style-name="T49">radius</text:span> for the well used to calculate a well’s productivity or injectivity index. </text:p>
-       <text:p text:style-name="P50">A default of zero results in the pressure equivalent radius of the grid blocks containing the well connections are used.</text:p>
+       <text:p text:style-name="P135">A real value that defines the well drainage radius for the well used to calculate a well’s productivity or injectivity index. </text:p>
+       <text:p text:style-name="P135">A default of zero results in the pressure equivalent radius of the grid blocks containing the well connections are used.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F10" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P52">0.0</text:p>
+       <text:p text:style-name="P135">0.0</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:covered-table-cell table:style-name="Table665.C2"/>
       <table:covered-table-cell table:style-name="Table665.C2"/>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P25"><text:span text:style-name="T36">f</text:span>eet</text:p>
+       <text:p text:style-name="P136">feet</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P36">m</text:p>
+       <text:p text:style-name="P136">m</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P25">cm</text:p>
+       <text:p text:style-name="P136">cm</text:p>
       </table:table-cell>
       <table:covered-table-cell table:style-name="Table665.F10"/>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P54">8</text:p>
+       <text:p text:style-name="P135">8</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P50">INFLOW</text:p>
+       <text:p text:style-name="P135">INFLOW</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P38">A defined character string that defines the inflow equation to be used for the well in calculating the well’s flow rates. INFLOW should be set to one of the following character strings:</text:p>
+       <text:p text:style-name="P135">A defined character string that defines the inflow equation to be used for the well in calculating the well’s flow rates. INFLOW should be set to one of the following character strings:</text:p>
        <text:list text:continue-numbering="true" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P128"><text:span text:style-name="T44">STD</text:span>: <text:span text:style-name="T40">the standard inflow equation will be used. This is normally used for wells that are primary oil or water wells.</text:span></text:p>
+         <text:p text:style-name="P137">STD: the standard inflow equation will be used. This is normally used for wells that are primary oil or water wells.</text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P131">NO: an alias for STD.</text:p>
+         <text:p text:style-name="P137">NO: an alias for STD.</text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P132"><text:span text:style-name="T44">R-G</text:span>: <text:span text:style-name="T40">t</text:span>he <text:span text:style-name="T44">Russell Goodrich</text:span><text:span text:style-name="T44"><text:note text:id="ftn1" text:note-class="footnote"><text:note-citation>1</text:note-citation><text:note-body>
-             <text:p text:style-name="P53">Russell, D.G., Goodrich, J.H., Perry, G.E and Bruskotter, J.F &quot;Methods of Predicting Gas Well Performance&quot;, Transactions of the ASME, Journal of Petroleum Technology (1966) 99-108.</text:p></text:note-body></text:note></text:span><text:span text:style-name="T44"> pressure square inflow equation </text:span>w<text:span text:style-name="T45">i</text:span>ll <text:span text:style-name="T44">used. This option can be used for dry gas wells. </text:span></text:p>
+         <text:p text:style-name="P137">R-G: the Russell Goodrich<text:note text:id="ftn1" text:note-class="footnote"><text:note-citation>1</text:note-citation><text:note-body>
+            <text:p text:style-name="P65">Russell, D.G., Goodrich, J.H., Perry, G.E and Bruskotter, J.F &quot;Methods of Predicting Gas Well Performance&quot;, Transactions of the ASME, Journal of Petroleum Technology (1966) 99-108.</text:p></text:note-body></text:note> pressure square inflow equation will used. This option can be used for dry gas wells. </text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P132"><text:span text:style-name="T44">YES: an alias for R-G</text:span>.</text:p>
+         <text:p text:style-name="P137">YES: an alias for R-G.</text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P132"><text:span text:style-name="T44">P-P</text:span>: <text:span text:style-name="T40">the general dry gas pseudo pressure inflow equation will be used. Normally used for dry gas wells.</text:span></text:p>
+         <text:p text:style-name="P137">P-P: the general dry gas pseudo pressure inflow equation will be used. Normally used for dry gas wells.</text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P132"><text:span text:style-name="T40">GPP</text:span>: <text:span text:style-name="T38">the generalized gas pseudo pressure inflow equation used with wet gas wells, that is condensate gas wells. This inflow equation is based on the formulation of Whitson et al.</text:span><text:span text:style-name="T38"><text:note text:id="ftn2" text:note-class="footnote"><text:note-citation>2</text:note-citation><text:note-body>
-             <text:p text:style-name="P58">Whitson, C. H. and Fevang, Ø. “Generalised Pseudopressure Well Treatment in Reservoir Simulation,” Presented at the IBC Technical Services Conference on Optimisation of Gas Condensate Fields, Aberdeen, UK (June 26-27, 1997).</text:p></text:note-body></text:note></text:span></text:p>
+         <text:p text:style-name="P137">GPP: the generalized gas pseudo pressure inflow equation used with wet gas wells, that is condensate gas wells. This inflow equation is based on the formulation of Whitson et al.<text:note text:id="ftn2" text:note-class="footnote"><text:note-citation>2</text:note-citation><text:note-body>
+            <text:p text:style-name="P70">Whitson, C. H. and Fevang, Ø. “Generalised Pseudopressure Well Treatment in Reservoir Simulation,” Presented at the IBC Technical Services Conference on Optimisation of Gas Condensate Fields, Aberdeen, UK (June 26-27, 1997).</text:p></text:note-body></text:note></text:p>
         </text:list-item>
        </text:list>
-       <text:p text:style-name="P51">For oil and water wells the INFLOW should be set to STD, wh<text:span text:style-name="T52">ereas</text:span> for dry gas wells INFLOW can be set to either R-G or P-P; <text:span text:style-name="T45">however, the P-P option is preferred for dry gas wells due to the more rigorous treatment of gas flow</text:span>. <text:s/>For wet gas wells, that is gas condensate wells, INFLOW should be set to GPP. </text:p>
-       <text:p text:style-name="P60">Only INFLOW equal to STD and NO are currently implemented in OPM Flow.</text:p>
+       <text:p text:style-name="P135">For oil and water wells the INFLOW should be set to STD, whereas for dry gas wells INFLOW can be set to either R-G or P-P; however, the P-P option is preferred for dry gas wells due to the more rigorous treatment of gas flow. <text:s/>For wet gas wells, that is gas condensate wells, INFLOW should be set to GPP. </text:p>
+       <text:p text:style-name="P135">Only INFLOW equal to STD and NO are currently implemented in OPM Flow.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" office:value-type="string">
-       <text:p text:style-name="P52">STD</text:p>
+       <text:p text:style-name="P135">STD</text:p>
       </table:table-cell>
      </table:table-row>
      <text:soft-page-break/>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P54">9</text:p>
+       <text:p text:style-name="P135">9</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P55">AUTO</text:p>
+       <text:p text:style-name="P135">AUTO</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P120">A defined character string that defines the <text:span text:style-name="T45">automatic </text:span>action to be taken if the economic WCUT, GOR, or WGR limits are violated <text:span text:style-name="T45">and the well is to cease production.</text:span> A<text:span text:style-name="T45">UTO</text:span> should be set to one of the following character strings:</text:p>
+       <text:p text:style-name="P133">A defined character string that defines the automatic action to be taken if the economic WCUT, GOR, or WGR limits are violated and the well is to cease production. AUTO should be set to one of the following character strings:</text:p>
        <text:list text:continue-numbering="true" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P133">STOP: the well is “stopped” at the surface and will not produce any fluids to surface; however, if there any open connections then flow may occur within the wellbore and between the open connections depending on a connection’s potential with respect to all the other connections. <text:s/>Inter-connection flow (cross flow) can be prevented by setting the XFLOW variable to NO. In this case the well’s behavior will be similar to the SHUT option described below. </text:p>
+         <text:p text:style-name="P137">STOP: the well is “stopped” at the surface and will not produce any fluids to surface; however, if there any open connections then flow may occur within the wellbore and between the open connections depending on a connection’s potential with respect to all the other connections. <text:s/>Inter-connection flow (cross flow) can be prevented by setting the XFLOW variable to NO. In this case the well’s behavior will be similar to the SHUT option described below. </text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P134"><text:span text:style-name="T30">SHUT: </text:span><text:span text:style-name="T31">the well is shut at the surface and downhole, this results in no flow at the surface and no cross flow downhole. </text:span></text:p>
+         <text:p text:style-name="P137">SHUT: the well is shut at the surface and downhole, this results in no flow at the surface and no cross flow downhole. </text:p>
         </text:list-item>
        </text:list>
-       <text:p text:style-name="P118">The corrective action takes places at the en<text:span text:style-name="T43">d</text:span> of the time step in which the constraint is violated.</text:p>
+       <text:p text:style-name="P135">The corrective action takes places at the end of the time step in which the constraint is violated.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" office:value-type="string">
-       <text:p text:style-name="P61">SHUT</text:p>
+       <text:p text:style-name="P135">SHUT</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P54">10</text:p>
+       <text:p text:style-name="P135">10</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P55">XFLOW</text:p>
+       <text:p text:style-name="P135">XFLOW</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P120">A defined character string that defines the <text:span text:style-name="T45">if cross flow should occur within the wellbore, and should be set to either:</text:span></text:p>
+       <text:p text:style-name="P133">A defined character string that defines the if cross flow should occur within the wellbore, and should be set to either:</text:p>
        <text:list text:continue-numbering="true" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P136">YES: to allow cross flow in the wellbore through well connections.</text:p>
+         <text:p text:style-name="P137">YES: to allow cross flow in the wellbore through well connections.</text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P134"><text:span text:style-name="T32">NO</text:span><text:span text:style-name="T30">: </text:span><text:span text:style-name="T32">to disallow cross flow within the wellbore, even if the flow potentials in the well connections would allow such flow to occur.</text:span></text:p>
+         <text:p text:style-name="P137">NO: to disallow cross flow within the wellbore, even if the flow potentials in the well connections would allow such flow to occur.</text:p>
         </text:list-item>
        </text:list>
-       <text:p text:style-name="P56"><text:span text:style-name="T29">In some cases numerical issues can occur if this variable is set to YES, and resetting it to NO may resolve the issue; however, the results may not represent the physical </text:span><text:span text:style-name="T34">down hole </text:span><text:span text:style-name="T29">process in this case.</text:span></text:p>
+       <text:p text:style-name="P135">In some cases numerical issues can occur if this variable is set to YES, and resetting it to NO may resolve the issue; however, the results may not represent the physical down hole process in this case.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" office:value-type="string">
-       <text:p text:style-name="P54">YES</text:p>
+       <text:p text:style-name="P135">YES</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P61">11</text:p>
+       <text:p text:style-name="P135">11</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P62">PVTNUM</text:p>
+       <text:p text:style-name="P135">PVTNUM</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P40">A <text:span text:style-name="T41">po</text:span>sitive <text:span text:style-name="T41">integer greater than or equal to zero </text:span>that defines the<text:span text:style-name="T27"> PVT table used to calculate the wellbore fluid properties that define the relationship between reservoir and surface volume rates.</text:span></text:p>
-       <text:p text:style-name="P63">The default value of zero sets PVTNUM to be the PVT table of the deepest connection in the well. </text:p>
+       <text:p text:style-name="P135">A positive integer greater than or equal to zero that defines the PVT table used to calculate the wellbore fluid properties that define the relationship between reservoir and surface volume rates.</text:p>
+       <text:p text:style-name="P135">The default value of zero sets PVTNUM to be the PVT table of the deepest connection in the well. </text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F15" office:value-type="string">
-       <text:p text:style-name="P61">0</text:p>
+       <text:p text:style-name="P135">0</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P61">12</text:p>
+       <text:p text:style-name="P135">12</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P62">DENOPT</text:p>
+       <text:p text:style-name="P135">DENOPT</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P63">A defined character string that sets the type of density calculation used in calculating the wellbore hydrostatic head, and should be set to one of the following character strings:</text:p>
+       <text:p text:style-name="P135">A defined character string that sets the type of density calculation used in calculating the wellbore hydrostatic head, and should be set to one of the following character strings:</text:p>
        <text:list text:continue-numbering="true" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P135"><text:span text:style-name="T46">SEG: sets the hydrostatic head density calculation to segmented. In this cases the density is calculated between neighboring well connections and the volumes flowing from the connections. This is the more accurate calculation if the fluid properties flowing from the well connections are variable. The density calculation itself is explicit, </text:span>i.e.<text:span text:style-name="T50"> uses the flowing volumes of the last time step.</text:span></text:p>
+         <text:p text:style-name="P137">SEG: sets the hydrostatic head density calculation to segmented. In this cases the density is calculated between neighboring well connections and the volumes flowing from the connections. This is the more accurate calculation if the fluid properties flowing from the well connections are variable. The density calculation itself is explicit, i.e. uses the flowing volumes of the last time step.</text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P135"><text:span text:style-name="T33">AVG</text:span><text:span text:style-name="T30">: </text:span><text:span text:style-name="T33">sets the hydrostatic head density calculation to the average density calculation. Here the density is considered uniform across a given reservoir and is dependent on total inflow rates of each phase and the well’s bottom-hole pressure</text:span></text:p>
+         <text:p text:style-name="P137">AVG: sets the hydrostatic head density calculation to the average density calculation. Here the density is considered uniform across a given reservoir and is dependent on total inflow rates of each phase and the well’s bottom-hole pressure</text:p>
         </text:list-item>
        </text:list>
-       <text:p text:style-name="P119">The default option of 1* invokes the SEG option <text:span text:style-name="T51">and is the only option implemented in OPM Flow.</text:span></text:p>
+       <text:p text:style-name="P135">The default option of 1* invokes the SEG option and is the only option implemented in OPM Flow.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F15" office:value-type="string">
-       <text:p text:style-name="P61">SEG</text:p>
+       <text:p text:style-name="P135">SEG</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.A17" office:value-type="string">
-       <text:p text:style-name="P61">13</text:p>
+       <text:p text:style-name="P135">13</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P62">FIPNUM</text:p>
+       <text:p text:style-name="P135">FIPNUM</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P40">A<text:span text:style-name="T46">n</text:span> <text:span text:style-name="T41">integer value</text:span> defines the<text:span text:style-name="T27"> FIPNUM region used to determine the reservoir conditions in calculating the well’s reservoir volumes </text:span><text:span text:style-name="T52">and is determined by:</text:span></text:p>
+       <text:p text:style-name="P135">An integer value defines the FIPNUM region used to determine the reservoir conditions in calculating the well’s reservoir volumes and is determined by:</text:p>
        <text:list text:continue-numbering="true" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
          <text:p text:style-name="P137">If set to a negative integer value then the FIPNUM region of the deepest connection in the well will be used.</text:p>
@@ -5417,91 +5326,91 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
          <text:p text:style-name="P137">If set to zero, the default value, then the average properties for the field will be used.</text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P137">If set to <text:span text:style-name="T47">an integer value greater than zero, then the FIPNUM indicated by this value will be used.</text:span> </text:p>
+         <text:p text:style-name="P137">If set to an integer value greater than zero, then the FIPNUM indicated by this value will be used. </text:p>
         </text:list-item>
        </text:list>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F15" office:value-type="string">
-       <text:p text:style-name="P61">0</text:p>
+       <text:p text:style-name="P135">0</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.A18" office:value-type="string">
-       <text:p text:style-name="P61">14</text:p>
+       <text:p text:style-name="P135">14</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P67">STRMLIN1</text:p>
+       <text:p text:style-name="P135">STRMLIN1</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P63">Not used <text:span text:style-name="T52">and should be defaulted with 1*.</text:span></text:p>
+       <text:p text:style-name="P135">Not used and should be defaulted with 1*.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F15" office:value-type="string">
-       <text:p text:style-name="P65">1*</text:p>
+       <text:p text:style-name="P135">1*</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.A18" office:value-type="string">
-       <text:p text:style-name="P61">15</text:p>
+       <text:p text:style-name="P135">15</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P67">STRMLIN2</text:p>
+       <text:p text:style-name="P135">STRMLIN2</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P63">Not used <text:span text:style-name="T52">and should be defaulted with 1*.</text:span></text:p>
+       <text:p text:style-name="P135">Not used and should be defaulted with 1*.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F15" office:value-type="string">
-       <text:p text:style-name="P65">1*</text:p>
-      </table:table-cell>
-     </table:table-row>
-     <table:table-row table:style-name="Table665.1">
-      <table:table-cell table:style-name="Table665.A18" office:value-type="string">
-       <text:p text:style-name="P61">16</text:p>
-      </table:table-cell>
-      <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P66">TYPECOMP</text:p>
-      </table:table-cell>
-      <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P63"><text:span text:style-name="T52">Commercial compositional simulator well type model option that is n</text:span>ot used <text:span text:style-name="T52">and should be defaulted with either STD or 1*.</text:span></text:p>
-      </table:table-cell>
-      <table:covered-table-cell/>
-      <table:covered-table-cell/>
-      <table:table-cell table:style-name="Table665.F15" office:value-type="string">
-       <text:p text:style-name="P121">STD</text:p>
+       <text:p text:style-name="P135">1*</text:p>
       </table:table-cell>
      </table:table-row>
      <text:soft-page-break/>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.A18" office:value-type="string">
-       <text:p text:style-name="P61">17</text:p>
+       <text:p text:style-name="P135">16</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P66">POLYTAB</text:p>
+       <text:p text:style-name="P135">TYPECOMP</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P30">A positive integer greater than or equal to zero <text:span text:style-name="T52">that defines the polymer mixing table, </text:span><text:span text:style-name="T53">as defined by the </text:span><text:span text:style-name="T35">PLMIXPAR and PLYMAX keywords,</text:span><text:span text:style-name="T52"> to be used in calculating the well’s well bore properties. The default value of z</text:span><text:span text:style-name="T53">ero means the table allocated via the PLMIXNUM array for the deepest connection in the well bore </text:span><text:span text:style-name="T54">is </text:span><text:span text:style-name="T24">utilized.</text:span></text:p>
-       <text:p text:style-name="P68">Only the default value of zero is supported by OPM Flow.</text:p>
+       <text:p text:style-name="P135">Commercial compositional simulator well type model option that is not used and should be defaulted with either STD or 1*.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F15" office:value-type="string">
-       <text:p text:style-name="P65">0</text:p>
+       <text:p text:style-name="P135">STD</text:p>
+      </table:table-cell>
+     </table:table-row>
+     <table:table-row table:style-name="Table665.1">
+      <table:table-cell table:style-name="Table665.A18" office:value-type="string">
+       <text:p text:style-name="P135">17</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table665.C2" office:value-type="string">
+       <text:p text:style-name="P135">POLYTAB</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table665.C2" table:number-columns-spanned="3" office:value-type="string">
+       <text:p text:style-name="P135">A positive integer greater than or equal to zero that defines the polymer mixing table, as defined by the PLMIXPAR and PLYMAX keywords, to be used in calculating the well’s well bore properties. The default value of zero means the table allocated via the PLMIXNUM array for the deepest connection in the well bore is utilized.</text:p>
+       <text:p text:style-name="P135">Only the default value of zero is supported by OPM Flow.</text:p>
+      </table:table-cell>
+      <table:covered-table-cell/>
+      <table:covered-table-cell/>
+      <table:table-cell table:style-name="Table665.F15" office:value-type="string">
+       <text:p text:style-name="P135">0</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.A22" table:number-columns-spanned="6" office:value-type="string">
-       <text:p text:style-name="P24">Notes:</text:p>
+       <text:p text:style-name="P136">Notes:</text:p>
        <text:list text:style-name="L1">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P138"><text:span text:style-name="T23">T</text:span><text:span text:style-name="T20">he keyword is followed by </text:span><text:span text:style-name="T22">any number</text:span><text:span text:style-name="T19"> records</text:span><text:span text:style-name="T20"> </text:span><text:span text:style-name="T22">with e</text:span><text:span text:style-name="T19">ach record terminated by a “/” and the </text:span><text:span text:style-name="T21">keyword should be terminated by a </text:span><text:span text:style-name="T19">“/”.</text:span></text:p>
+         <text:p text:style-name="P138">The keyword is followed by any number records with each record terminated by a “/” and the keyword should be terminated by a “/”.</text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P143">Note that the total number of individual wells declared by the WELSPECS cannot exceed the valued entered via the MXWELS variable on the WELLDIMS keyword in the RUNSPEC section.</text:p>
+         <text:p text:style-name="P138">Note that the total number of individual wells declared by the WELSPECS cannot exceed the valued entered via the MXWELS variable on the WELLDIMS keyword in the RUNSPEC section.</text:p>
         </text:list-item>
        </text:list>
       </table:table-cell>
@@ -5512,35 +5421,35 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
      </table:table-row>
     </table:table>
-    <text:p text:style-name="P80">Table <text:sequence text:ref-name="refTable0" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">12.3.281.1</text:sequence>: WELSPECS Keyword Description</text:p>
-    <text:p text:style-name="P81"/>
-    <text:p text:style-name="P81">See also the COMPDAT keyword to define a well’s connections, the WCONPROD and WCONINJE keywords to define a well’s production and injection targets and constraints. All the aforementioned keywords are described in the SCHEDULE section.</text:p>
-    <text:h text:style-name="P84" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc716755_3964674244"/>Example<text:bookmark-end text:name="__RefHeading___Toc716755_3964674244"/></text:h>
-    <text:p text:style-name="P75">The following example defines t<text:span text:style-name="T47">hree</text:span> wells using the WELSPECS keyword </text:p>
-    <text:p text:style-name="P78">--</text:p>
-    <text:p text:style-name="P78">-- <text:s text:c="6"/>WELL SPECIFICATION DATA <text:s text:c="53"/></text:p>
-    <text:p text:style-name="P78">-- <text:s text:c="77"/></text:p>
-    <text:p text:style-name="P78">-- WELL <text:s/>GROUP <text:s text:c="4"/>LOCATION <text:s/>BHP <text:s text:c="3"/>PHASE <text:s/>DRAIN <text:s/>INFLOW <text:s/>OPEN <text:s/>CROSS <text:s/>PVT <text:s text:c="8"/></text:p>
-    <text:p text:style-name="P78">-- NAME <text:s/>NAME <text:s text:c="7"/>I <text:s text:c="3"/>J <text:s/>DEPTH <text:s/>FLUID <text:s/>AREA <text:s text:c="2"/>EQUANS <text:s/>SHUT <text:s/>FLOW <text:s text:c="2"/>TABLE <text:s text:c="6"/></text:p>
-    <text:p text:style-name="P78">WELSPECS <text:s text:c="154"/></text:p>
-    <text:p text:style-name="P78">GI01 <text:s text:c="4"/>PLATFORM <text:s text:c="2"/>14 <text:s text:c="2"/>13 <text:s text:c="2"/>1* <text:s text:c="4"/>GAS <text:s text:c="3"/>1* <text:s text:c="4"/>P-P <text:s text:c="3"/>SHUT <text:s text:c="2"/>NO <text:s text:c="4"/>1* <text:s text:c="4"/>/</text:p>
-    <text:p text:style-name="P78">GP01 <text:s text:c="4"/>PLATFORM <text:s text:c="2"/>64 <text:s text:c="2"/>80 <text:s text:c="2"/>1* <text:s text:c="4"/>GAS <text:s text:c="3"/>1* <text:s text:c="4"/>GPP <text:s text:c="3"/>SHUT <text:s text:c="2"/>NO <text:s text:c="4"/>1* <text:s text:c="4"/>/</text:p>
-    <text:p text:style-name="P78">OP01 <text:s text:c="4"/>PLATFORM <text:s text:c="2"/>24 <text:s/>110 <text:s text:c="2"/>1* <text:s text:c="4"/>OIL <text:s text:c="3"/>1* <text:s text:c="4"/>STD <text:s text:c="3"/>SHUT <text:s text:c="2"/>NO <text:s text:c="4"/>1* <text:s text:c="4"/>/</text:p>
-    <text:p text:style-name="P76"><text:span text:style-name="T47">/ <text:s text:c="71"/></text:span><text:s text:c="77"/></text:p>
-    <text:p text:style-name="P82"/>
+    <text:p text:style-name="P94">Table <text:sequence text:ref-name="refTable0" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">12.3.281.1</text:sequence>: WELSPECS Keyword Description</text:p>
+    <text:p text:style-name="P134"/>
+    <text:p text:style-name="P134">See also the COMPDAT keyword to define a well’s connections, the WCONPROD and WCONINJE keywords to define a well’s production and injection targets and constraints. All the aforementioned keywords are described in the SCHEDULE section.</text:p>
+    <text:h text:style-name="P98" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc716755_3964674244"/>Example<text:bookmark-end text:name="__RefHeading___Toc716755_3964674244"/></text:h>
+    <text:p text:style-name="P129">The following example defines three wells using the WELSPECS keyword </text:p>
+    <text:p text:style-name="P128">--</text:p>
+    <text:p text:style-name="P128">-- <text:s text:c="6"/>WELL SPECIFICATION DATA <text:s text:c="53"/></text:p>
+    <text:p text:style-name="P128">-- <text:s text:c="77"/></text:p>
+    <text:p text:style-name="P128">-- WELL <text:s/>GROUP <text:s text:c="4"/>LOCATION <text:s/>BHP <text:s text:c="3"/>PHASE <text:s/>DRAIN <text:s/>INFLOW <text:s/>OPEN <text:s/>CROSS <text:s/>PVT <text:s text:c="8"/></text:p>
+    <text:p text:style-name="P128">-- NAME <text:s/>NAME <text:s text:c="7"/>I <text:s text:c="3"/>J <text:s/>DEPTH <text:s/>FLUID <text:s/>AREA <text:s text:c="2"/>EQUANS <text:s/>SHUT <text:s/>FLOW <text:s text:c="2"/>TABLE <text:s text:c="6"/></text:p>
+    <text:p text:style-name="P128">WELSPECS <text:s text:c="154"/></text:p>
+    <text:p text:style-name="P128">GI01 <text:s text:c="4"/>PLATFORM <text:s text:c="2"/>14 <text:s text:c="2"/>13 <text:s text:c="2"/>1* <text:s text:c="4"/>GAS <text:s text:c="3"/>1* <text:s text:c="4"/>P-P <text:s text:c="3"/>SHUT <text:s text:c="2"/>NO <text:s text:c="4"/>1* <text:s text:c="4"/>/</text:p>
+    <text:p text:style-name="P128">GP01 <text:s text:c="4"/>PLATFORM <text:s text:c="2"/>64 <text:s text:c="2"/>80 <text:s text:c="2"/>1* <text:s text:c="4"/>GAS <text:s text:c="3"/>1* <text:s text:c="4"/>GPP <text:s text:c="3"/>SHUT <text:s text:c="2"/>NO <text:s text:c="4"/>1* <text:s text:c="4"/>/</text:p>
+    <text:p text:style-name="P128">OP01 <text:s text:c="4"/>PLATFORM <text:s text:c="2"/>24 <text:s/>110 <text:s text:c="2"/>1* <text:s text:c="4"/>OIL <text:s text:c="3"/>1* <text:s text:c="4"/>STD <text:s text:c="3"/>SHUT <text:s text:c="2"/>NO <text:s text:c="4"/>1* <text:s text:c="4"/>/</text:p>
+    <text:p text:style-name="P128">/ <text:s text:c="148"/></text:p>
+    <text:p text:style-name="P134"/>
     <text:p text:style-name="_40_TextBody">Here, well GI01 is a dry gas injection well that uses the dry gas pseudo inflow equation, GP01 is a gas condensate well that uses the generalized gas pseudo pressure inflow equation, and finally, OP01 is an oil well that uses the standard inflow equation. All wells will be shut if they are required to cease production, all wells disallow cross flow, <text:s/>and the hydrostatic head calculation is defaulted to the segment option for all wells.</text:p>
     <text:p text:style-name="_40_TextBody">If the same three wells are using the COMPTRAJ and WELTRAJ keywords to specify the connections to the simulation grid, then the WELSPECS keyword should be;</text:p>
-    <text:p text:style-name="P79">--</text:p>
-    <text:p text:style-name="P79">-- <text:s text:c="6"/>WELL SPECIFICATION DATA <text:s text:c="53"/></text:p>
-    <text:p text:style-name="P79">-- <text:s text:c="77"/></text:p>
-    <text:p text:style-name="P79">-- WELL <text:s/>GROUP <text:s text:c="4"/>LOCATION <text:s/>BHP <text:s text:c="3"/>PHASE <text:s/>DRAIN <text:s/>INFLOW <text:s/>OPEN <text:s/>CROSS <text:s/>PVT <text:s text:c="8"/></text:p>
-    <text:p text:style-name="P79">-- NAME <text:s/>NAME <text:s text:c="7"/>I <text:s text:c="3"/>J <text:s/>DEPTH <text:s/>FLUID <text:s/>AREA <text:s text:c="2"/>EQUANS <text:s/>SHUT <text:s/>FLOW <text:s text:c="2"/>TABLE <text:s text:c="6"/></text:p>
-    <text:p text:style-name="P79">WELSPECS <text:s text:c="154"/></text:p>
-    <text:p text:style-name="P79">GI01 <text:s text:c="4"/>PLATFORM <text:s text:c="2"/>1* <text:s text:c="2"/>1* <text:s text:c="2"/>1* <text:s text:c="4"/>GAS <text:s text:c="3"/>1* <text:s text:c="4"/>P-P <text:s text:c="3"/>SHUT <text:s text:c="2"/>NO <text:s text:c="4"/>1* <text:s text:c="4"/>/</text:p>
-    <text:p text:style-name="P79">GP01 <text:s text:c="4"/>PLATFORM <text:s text:c="2"/>1* <text:s text:c="2"/>1* <text:s text:c="2"/>1* <text:s text:c="4"/>GAS <text:s text:c="3"/>1* <text:s text:c="4"/>GPP <text:s text:c="3"/>SHUT <text:s text:c="2"/>NO <text:s text:c="4"/>1* <text:s text:c="4"/>/</text:p>
-    <text:p text:style-name="P79">OP01 <text:s text:c="4"/>PLATFORM <text:s text:c="2"/>1* <text:s text:c="2"/>1* <text:s text:c="2"/>1* <text:s text:c="4"/>OIL <text:s text:c="3"/>1* <text:s text:c="4"/>STD <text:s text:c="3"/>SHUT <text:s text:c="2"/>NO <text:s text:c="4"/>1* <text:s text:c="4"/>/</text:p>
-    <text:p text:style-name="P77"><text:span text:style-name="T47">/ <text:s text:c="71"/></text:span><text:s text:c="77"/></text:p>
-    <text:p text:style-name="_40_TextBody">Notice how the well <text:span text:style-name="T61">location </text:span>parameter<text:span text:style-name="T61">s have been defaulted with 1* in this case.</text:span></text:p>
+    <text:p text:style-name="P128">--</text:p>
+    <text:p text:style-name="P128">-- <text:s text:c="6"/>WELL SPECIFICATION DATA <text:s text:c="53"/></text:p>
+    <text:p text:style-name="P128">-- <text:s text:c="77"/></text:p>
+    <text:p text:style-name="P128">-- WELL <text:s/>GROUP <text:s text:c="4"/>LOCATION <text:s/>BHP <text:s text:c="3"/>PHASE <text:s/>DRAIN <text:s/>INFLOW <text:s/>OPEN <text:s/>CROSS <text:s/>PVT <text:s text:c="8"/></text:p>
+    <text:p text:style-name="P128">-- NAME <text:s/>NAME <text:s text:c="7"/>I <text:s text:c="3"/>J <text:s/>DEPTH <text:s/>FLUID <text:s/>AREA <text:s text:c="2"/>EQUANS <text:s/>SHUT <text:s/>FLOW <text:s text:c="2"/>TABLE <text:s text:c="6"/></text:p>
+    <text:p text:style-name="P128">WELSPECS <text:s text:c="154"/></text:p>
+    <text:p text:style-name="P128">GI01 <text:s text:c="4"/>PLATFORM <text:s text:c="2"/>1* <text:s text:c="2"/>1* <text:s text:c="2"/>1* <text:s text:c="4"/>GAS <text:s text:c="3"/>1* <text:s text:c="4"/>P-P <text:s text:c="3"/>SHUT <text:s text:c="2"/>NO <text:s text:c="4"/>1* <text:s text:c="4"/>/</text:p>
+    <text:p text:style-name="P128">GP01 <text:s text:c="4"/>PLATFORM <text:s text:c="2"/>1* <text:s text:c="2"/>1* <text:s text:c="2"/>1* <text:s text:c="4"/>GAS <text:s text:c="3"/>1* <text:s text:c="4"/>GPP <text:s text:c="3"/>SHUT <text:s text:c="2"/>NO <text:s text:c="4"/>1* <text:s text:c="4"/>/</text:p>
+    <text:p text:style-name="P128">OP01 <text:s text:c="4"/>PLATFORM <text:s text:c="2"/>1* <text:s text:c="2"/>1* <text:s text:c="2"/>1* <text:s text:c="4"/>OIL <text:s text:c="3"/>1* <text:s text:c="4"/>STD <text:s text:c="3"/>SHUT <text:s text:c="2"/>NO <text:s text:c="4"/>1* <text:s text:c="4"/>/</text:p>
+    <text:p text:style-name="P128">/ <text:s text:c="148"/></text:p>
+    <text:p text:style-name="_40_TextBody">Notice how the well location parameters have been defaulted with 1* in this case.</text:p>
    </text:section>
   </office:text>
  </office:body>


### PR DESCRIPTION
When the general well specification data is defined by the WELSPECS keyword in the SCHEDULE section the well can now be assigned directly to the FIELD group in item 2 GRPNAME (#3485 and #4608). Previously there was a restriction preventing wells from being parented directly to FIELD. Although wells are now allowed to be parented directly to FIELD, this is discouraged and a warning message will be issued. Mixing wells and groups as children of a single group is still forbidden.