### PR TITLE
Update FOAMOPTS.fodt for 2023-10

### DIFF
--- a/parts/chapters/subsections/8.3/FOAMOPTS.fodt
+++ b/parts/chapters/subsections/8.3/FOAMOPTS.fodt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:officeooo="http://openoffice.org/2009/office" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
- <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT5H30M48S</meta:editing-duration><meta:editing-cycles>24</meta:editing-cycles><meta:generator>LibreOffice/7.6.2.1$Windows_X86_64 LibreOffice_project/56f7684011345957bbf33a7ee678afaf4d2ba333</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
+ <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT5H47M1S</meta:editing-duration><meta:editing-cycles>25</meta:editing-cycles><meta:generator>LibreOffice/7.6.2.1$Windows_X86_64 LibreOffice_project/56f7684011345957bbf33a7ee678afaf4d2ba333</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
 1) eq 
 2) F3
 
@@ -17,10 +17,10 @@ To insert a new keyword section (except for the header
 To insert standard text:
 1) t0, t1, t2
 2) F3
-Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:initial-creator>David Baxendale</meta:initial-creator><dc:date>2023-12-11T16:25:59.873000000</dc:date><meta:document-statistic meta:table-count="9" meta:image-count="0" meta:object-count="0" meta:page-count="2" meta:paragraph-count="109" meta:word-count="501" meta:character-count="2971" meta:non-whitespace-character-count="2228"/><meta:user-defined meta:name="ClientContact">ClientContact</meta:user-defined><meta:user-defined meta:name="ClientEmail">ClientEmail</meta:user-defined><meta:user-defined meta:name="ClientName">Equinor ASA</meta:user-defined><meta:user-defined meta:name="ClientOffice">ClientOfficeAddres</meta:user-defined><meta:user-defined meta:name="ClientRegistered" meta:value-type="string">ClientRegisteredAddress</meta:user-defined><meta:user-defined meta:name="ClientTelNo" meta:value-type="string">ClientTelNo</meta:user-defined><meta:user-defined meta:name="DocumentDate" meta:value-type="string">June 8, 2023</meta:user-defined><meta:user-defined meta:name="DocumentNumber" meta:value-type="string">2023-04-RPT</meta:user-defined><meta:user-defined meta:name="DocumentRevision" meta:value-type="string">Rev-0</meta:user-defined><meta:user-defined meta:name="ProgramVersion" meta:value-type="string">2023-04</meta:user-defined></office:meta>
+Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:initial-creator>David Baxendale</meta:initial-creator><dc:date>2023-12-19T11:47:00.614000000</dc:date><meta:document-statistic meta:table-count="9" meta:image-count="0" meta:object-count="0" meta:page-count="2" meta:paragraph-count="108" meta:word-count="492" meta:character-count="2931" meta:non-whitespace-character-count="2197"/><meta:user-defined meta:name="ClientContact">ClientContact</meta:user-defined><meta:user-defined meta:name="ClientEmail">ClientEmail</meta:user-defined><meta:user-defined meta:name="ClientName">Equinor ASA</meta:user-defined><meta:user-defined meta:name="ClientOffice">ClientOfficeAddres</meta:user-defined><meta:user-defined meta:name="ClientRegistered" meta:value-type="string">ClientRegisteredAddress</meta:user-defined><meta:user-defined meta:name="ClientTelNo" meta:value-type="string">ClientTelNo</meta:user-defined><meta:user-defined meta:name="DocumentDate" meta:value-type="string">June 8, 2023</meta:user-defined><meta:user-defined meta:name="DocumentNumber" meta:value-type="string">2023-04-RPT</meta:user-defined><meta:user-defined meta:name="DocumentRevision" meta:value-type="string">Rev-0</meta:user-defined><meta:user-defined meta:name="ProgramVersion" meta:value-type="string">2023-04</meta:user-defined></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
-   <config:config-item config:name="ViewAreaTop" config:type="long">35145</config:config-item>
+   <config:config-item config:name="ViewAreaTop" config:type="long">31750</config:config-item>
    <config:config-item config:name="ViewAreaLeft" config:type="long">0</config:config-item>
    <config:config-item config:name="ViewAreaWidth" config:type="long">21500</config:config-item>
    <config:config-item config:name="ViewAreaHeight" config:type="long">24370</config:config-item>
@@ -29,12 +29,12 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <config:config-item-map-indexed config:name="Views">
     <config:config-item-map-entry>
      <config:config-item config:name="ViewId" config:type="string">view2</config:config-item>
-     <config:config-item config:name="ViewLeft" config:type="long">9045</config:config-item>
-     <config:config-item config:name="ViewTop" config:type="long">52100</config:config-item>
+     <config:config-item config:name="ViewLeft" config:type="long">6595</config:config-item>
+     <config:config-item config:name="ViewTop" config:type="long">35338</config:config-item>
      <config:config-item config:name="VisibleLeft" config:type="long">0</config:config-item>
-     <config:config-item config:name="VisibleTop" config:type="long">35145</config:config-item>
+     <config:config-item config:name="VisibleTop" config:type="long">31750</config:config-item>
      <config:config-item config:name="VisibleRight" config:type="long">21498</config:config-item>
-     <config:config-item config:name="VisibleBottom" config:type="long">59514</config:config-item>
+     <config:config-item config:name="VisibleBottom" config:type="long">56118</config:config-item>
      <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutColumns" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutBookMode" config:type="boolean">false</config:config-item>
@@ -116,7 +116,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <config:config-item config:name="LoadReadonly" config:type="boolean">false</config:config-item>
    <config:config-item config:name="ClipAsCharacterAnchoredWriterFlyFrames" config:type="boolean">false</config:config-item>
    <config:config-item config:name="UseOldPrinterMetrics" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="Rsid" config:type="int">1878630</config:config-item>
+   <config:config-item config:name="Rsid" config:type="int">1915797</config:config-item>
    <config:config-item config:name="RsidRoot" config:type="int">130112</config:config-item>
    <config:config-item config:name="ProtectForm" config:type="boolean">false</config:config-item>
    <config:config-item config:name="MsWordCompTrailingBlanks" config:type="boolean">false</config:config-item>
@@ -508,7 +508,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
   </draw:fill-image>
   <style:default-style style:family="graphic">
    <style:graphic-properties svg:stroke-color="#000000" draw:fill-color="#99ccff" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.3cm" draw:shadow-offset-y="0.3cm" draw:start-line-spacing-horizontal="0.283cm" draw:start-line-spacing-vertical="0.283cm" draw:end-line-spacing-horizontal="0.283cm" draw:end-line-spacing-vertical="0.283cm" style:writing-mode="lr-tb" style:flow-with-text="false"/>
-   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0cm" style:font-independent-line-spacing="false">
+   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0cm" style:writing-mode="lr-tb" style:font-independent-line-spacing="false">
     <style:tab-stops/>
    </style:paragraph-properties>
    <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Times New Roman1" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="DejaVu Sans" style:font-size-asian="12pt" style:language-asian="zxx" style:country-asian="none" style:font-name-complex="Lucidasans1" style:font-size-complex="12pt" style:language-complex="zxx" style:country-complex="none"/>
@@ -997,15 +997,15 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:graphic-properties>
   </style:style>
   <style:style style:name="Frame" style:family="graphic">
-   <style:graphic-properties svg:width="17.189cm" fo:min-width="60%" svg:height="14.848cm" fo:min-height="56%" text:anchor-type="paragraph" svg:x="2.702cm" svg:y="0cm" fo:margin-left="0.508cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:run-through="foreground" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph-content" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" draw:fill="none" fo:padding="0.152cm" fo:border="0.06pt solid #000000" style:shadow="#000000 0.178cm 0.178cm" draw:shadow-opacity="100%" loext:rel-width-rel="paragraph" loext:rel-height-rel="paragraph">
+   <style:graphic-properties svg:width="17.189cm" fo:min-width="60%" svg:height="14.848cm" fo:min-height="56%" text:anchor-type="paragraph" svg:x="2.702cm" svg:y="0cm" fo:margin-left="0.508cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:run-through="foreground" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph-content" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" fo:background-color="transparent" draw:fill="none" fo:padding="0.152cm" fo:border="0.06pt solid #000000" style:shadow="#000000 0.178cm 0.178cm" draw:shadow-opacity="100%" loext:rel-width-rel="paragraph" loext:rel-height-rel="paragraph">
     <style:columns fo:column-count="1" fo:column-gap="0cm"/>
    </style:graphic-properties>
   </style:style>
   <style:style style:name="Formula" style:family="graphic">
-   <style:graphic-properties text:anchor-type="as-char" svg:y="0cm" fo:margin-left="0.051cm" fo:margin-right="0.051cm" style:wrap="parallel" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="middle" style:vertical-rel="text" draw:fill="none" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true"/>
+   <style:graphic-properties text:anchor-type="as-char" svg:y="0cm" fo:margin-left="0.051cm" fo:margin-right="0.051cm" style:wrap="parallel" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="middle" style:vertical-rel="text" fo:background-color="transparent" draw:fill="none" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true"/>
   </style:style>
   <style:style style:name="OLE" style:family="graphic">
-   <style:graphic-properties text:anchor-type="paragraph" svg:x="0cm" svg:y="0cm" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" draw:fill="none"/>
+   <style:graphic-properties text:anchor-type="paragraph" svg:x="0cm" svg:y="0cm" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" fo:background-color="transparent" draw:fill="none"/>
   </style:style>
   <text:outline-style style:name="Outline">
    <text:outline-level-style text:level="1" loext:num-list-format="CHAPTER %1%:" style:num-prefix="CHAPTER " style:num-suffix=":" style:num-format="1" text:start-value="8">
@@ -2525,6 +2525,11 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
   <style:style style:name="Table972.D2" style:family="table-cell">
    <style:table-cell-properties fo:padding="0.097cm" fo:border-left="0.05pt solid #000000" fo:border-right="0.05pt solid #000000" fo:border-top="none" fo:border-bottom="0.05pt solid #000000"/>
   </style:style>
+  <style:style style:name="Table972.A3" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="#ff950e" fo:padding="0.097cm" fo:border-left="0.05pt solid #000000" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.05pt solid #000000">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
   <style:style style:name="Table972.B3" style:family="table-cell">
    <style:table-cell-properties fo:padding="0.097cm" fo:border-left="0.05pt solid #000000" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.05pt solid #000000"/>
   </style:style>
@@ -2661,10 +2666,72 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
   <style:style style:name="P22" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="00c150f8" officeooo:paragraph-rsid="00c150f8" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P23" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P24" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="01198236" officeooo:paragraph-rsid="01198236" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P25" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="011b2ab8" officeooo:paragraph-rsid="011b2ab8" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P26" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="small-caps" fo:color="#0066cc" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="16pt" fo:language="en" fo:country="US" fo:font-style="italic" officeooo:paragraph-rsid="002e95e7" style:font-name-asian="BernhardMod BT Roman" style:font-size-asian="16pt" style:font-style-asian="italic" style:font-name-complex="BernhardMod BT Roman" style:font-size-complex="16pt" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="P27" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="10.795cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="14pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="06f8892a" style:font-size-asian="14pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="14pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P28" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="16pt" fo:language="en" fo:country="US" fo:font-style="italic" officeooo:paragraph-rsid="002e95e7" style:font-name-asian="BernhardMod BT Roman" style:font-size-asian="16pt" style:font-style-asian="italic" style:font-name-complex="BernhardMod BT Roman" style:font-size-complex="16pt" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="P29" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="10.795cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Cabin" fo:font-size="14pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="14pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="14pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P30" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="10.795cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="12pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="12pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="12pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P31" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="12pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001a71eb" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="12pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="12pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P32" style:family="paragraph" style:parent-style-name="Standard">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:writing-mode="page"/>
    <style:text-properties fo:font-size="6pt" fo:language="en" fo:country="US" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="5.25pt" style:font-size-complex="6pt"/>
   </style:style>
-  <style:style style:name="P23" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
+  <style:style style:name="P33" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
    <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
     <style:tab-stops>
@@ -2674,19 +2741,19 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P24" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P34" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
    <style:text-properties fo:language="en" fo:country="US" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="00531151" officeooo:paragraph-rsid="0b692b8d" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
-  <style:style style:name="P25" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P35" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="004069ac" officeooo:paragraph-rsid="0b692b8d"/>
   </style:style>
-  <style:style style:name="P26" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P36" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="0b6b2b35" officeooo:paragraph-rsid="0b6b2b35"/>
   </style:style>
-  <style:style style:name="P27" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P37" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -2696,11 +2763,11 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="0b6b2b35" officeooo:paragraph-rsid="0b6b2b35"/>
   </style:style>
-  <style:style style:name="P28" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P38" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="0b692b8d" officeooo:paragraph-rsid="0b692b8d"/>
   </style:style>
-  <style:style style:name="P29" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P39" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -2710,29 +2777,29 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="0b6b2b35"/>
   </style:style>
-  <style:style style:name="P30" style:family="paragraph" style:parent-style-name="Table_20_Heading">
+  <style:style style:name="P40" style:family="paragraph" style:parent-style-name="Table_20_Heading">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="0b692b8d"/>
   </style:style>
-  <style:style style:name="P31" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P41" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="0b692b8d"/>
   </style:style>
-  <style:style style:name="P32" style:family="paragraph" style:parent-style-name="_40_Example">
+  <style:style style:name="P42" style:family="paragraph" style:parent-style-name="_40_Example">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="0b692b8d"/>
   </style:style>
-  <style:style style:name="P33" style:family="paragraph" style:parent-style-name="Table">
+  <style:style style:name="P43" style:family="paragraph" style:parent-style-name="Table">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="0b692b8d"/>
   </style:style>
-  <style:style style:name="P34" style:family="paragraph" style:parent-style-name="Heading_20_3">
+  <style:style style:name="P44" style:family="paragraph" style:parent-style-name="Heading_20_3">
    <style:paragraph-properties fo:break-before="page"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="0b692b8d"/>
   </style:style>
-  <style:style style:name="P35" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P45" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="00f7410c" officeooo:paragraph-rsid="0b692b8d" fo:background-color="transparent"/>
   </style:style>
-  <style:style style:name="P36" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P46" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="0b6d29e4"/>
   </style:style>
-  <style:style style:name="P37" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.152cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -2742,10 +2809,10 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="0c2d8d58" officeooo:paragraph-rsid="0c2d8d58"/>
   </style:style>
-  <style:style style:name="P38" style:family="paragraph" style:parent-style-name="Heading_20_4">
+  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Heading_20_4">
    <style:text-properties fo:language="en" fo:country="US"/>
   </style:style>
-  <style:style style:name="P39" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -2755,7 +2822,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06305dda" officeooo:paragraph-rsid="0b6b2b35"/>
   </style:style>
-  <style:style style:name="P40" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -2765,12 +2832,39 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="066fc5c7" officeooo:paragraph-rsid="0b6b2b35"/>
   </style:style>
-  <style:style style:name="P41" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="020e813f" officeooo:paragraph-rsid="0b692b8d"/>
   </style:style>
-  <style:style style:name="P42" style:family="paragraph" style:parent-style-name="Footer">
+  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="_40_Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties officeooo:paragraph-rsid="14d36d55"/>
+  </style:style>
+  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+  </style:style>
+  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" officeooo:rsid="0117c15b" officeooo:paragraph-rsid="0117c15b" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" officeooo:paragraph-rsid="13ac3201" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" fo:language="en" fo:country="US" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Footer">
    <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
     <style:tab-stops>
@@ -2780,7 +2874,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="07061c8d" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P43" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
+  <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
    <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
     <style:tab-stops>
@@ -2789,95 +2883,6 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     </style:tab-stops>
    </style:paragraph-properties>
    <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P44" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="00c150f8" officeooo:paragraph-rsid="00c150f8" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P45" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P46" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="01198236" officeooo:paragraph-rsid="01198236" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="011b2ab8" officeooo:paragraph-rsid="011b2ab8" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops>
-     <style:tab-stop style:position="10.795cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="12pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="12pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="12pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="12pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001a71eb" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="12pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="12pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops>
-     <style:tab-stop style:position="10.795cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="14pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="06f8892a" style:font-size-asian="14pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="14pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="16pt" fo:language="en" fo:country="US" fo:font-style="italic" officeooo:paragraph-rsid="002e95e7" style:font-name-asian="BernhardMod BT Roman" style:font-size-asian="16pt" style:font-style-asian="italic" style:font-name-complex="BernhardMod BT Roman" style:font-size-complex="16pt" style:font-style-complex="italic"/>
-  </style:style>
-  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops>
-     <style:tab-stop style:position="10.795cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Cabin" fo:font-size="14pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="14pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="14pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="small-caps" fo:color="#0066cc" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="16pt" fo:language="en" fo:country="US" fo:font-style="italic" officeooo:paragraph-rsid="002e95e7" style:font-name-asian="BernhardMod BT Roman" style:font-size-asian="16pt" style:font-style-asian="italic" style:font-name-complex="BernhardMod BT Roman" style:font-size-complex="16pt" style:font-style-complex="italic"/>
-  </style:style>
-  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="_40_Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties officeooo:paragraph-rsid="14d36d55"/>
-  </style:style>
-  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
-  </style:style>
-  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" officeooo:rsid="0117c15b" officeooo:paragraph-rsid="0117c15b" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" officeooo:paragraph-rsid="13ac3201" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" fo:language="en" fo:country="US" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
   <style:style style:name="P61" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
@@ -2890,20 +2895,17 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
   <style:style style:name="P63" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
    <style:paragraph-properties style:page-number="auto"/>
   </style:style>
-  <style:style style:name="P64" style:family="paragraph" style:parent-style-name="_40_TextBody">
-   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="0b6d29e4"/>
-  </style:style>
-  <style:style style:name="P65" style:family="paragraph" style:parent-style-name="Heading_20_3">
+  <style:style style:name="P64" style:family="paragraph" style:parent-style-name="Heading_20_3">
    <style:paragraph-properties fo:break-before="page"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="0b692b8d"/>
   </style:style>
-  <style:style style:name="P66" style:family="paragraph" style:parent-style-name="Heading_20_4">
+  <style:style style:name="P65" style:family="paragraph" style:parent-style-name="Heading_20_4">
    <style:text-properties fo:language="en" fo:country="US"/>
   </style:style>
-  <style:style style:name="P67" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="First_20_Page">
+  <style:style style:name="P66" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="First_20_Page">
    <style:paragraph-properties style:page-number="auto"/>
   </style:style>
-  <style:style style:name="P68" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
+  <style:style style:name="P67" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -2913,7 +2915,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06305dda" officeooo:paragraph-rsid="0b6b2b35"/>
   </style:style>
-  <style:style style:name="P69" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
+  <style:style style:name="P68" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -2923,7 +2925,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="066fc5c7" officeooo:paragraph-rsid="0b6b2b35"/>
   </style:style>
-  <style:style style:name="P70" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="L1">
+  <style:style style:name="P69" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="L1">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="020e813f" officeooo:paragraph-rsid="0b692b8d"/>
@@ -2956,34 +2958,34 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <style:text-properties style:font-name="Gill Sans MT" officeooo:rsid="06f4e628"/>
   </style:style>
   <style:style style:name="T10" style:family="text">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="T11" style:family="text">
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="13ac3201"/>
-  </style:style>
-  <style:style style:name="T12" style:family="text">
    <style:text-properties fo:font-size="20pt" style:font-size-asian="20pt" style:font-size-complex="20pt"/>
   </style:style>
-  <style:style style:name="T13" style:family="text">
+  <style:style style:name="T11" style:family="text">
    <style:text-properties fo:font-size="20pt" fo:font-style="normal" style:font-size-asian="20pt" style:font-style-asian="normal" style:font-size-complex="20pt" style:font-style-complex="normal"/>
   </style:style>
-  <style:style style:name="T14" style:family="text">
+  <style:style style:name="T12" style:family="text">
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="20pt" fo:font-style="normal" style:font-size-asian="20pt" style:font-style-asian="normal" style:font-size-complex="20pt" style:font-style-complex="normal"/>
   </style:style>
-  <style:style style:name="T15" style:family="text">
+  <style:style style:name="T13" style:family="text">
    <style:text-properties fo:color="#000000" loext:opacity="100%" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="05a4c253" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="T16" style:family="text">
+  <style:style style:name="T14" style:family="text">
    <style:text-properties fo:color="#000000" loext:opacity="100%" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0b648cf8" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="T17" style:family="text">
+  <style:style style:name="T15" style:family="text">
    <style:text-properties fo:color="#000000" loext:opacity="100%" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0b79be81" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="T18" style:family="text">
+  <style:style style:name="T16" style:family="text">
    <style:text-properties officeooo:rsid="06f4e628"/>
   </style:style>
-  <style:style style:name="T19" style:family="text">
+  <style:style style:name="T17" style:family="text">
    <style:text-properties officeooo:rsid="07070fd2"/>
+  </style:style>
+  <style:style style:name="T18" style:family="text">
+   <style:text-properties fo:language="en" fo:country="US"/>
+  </style:style>
+  <style:style style:name="T19" style:family="text">
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="13ac3201"/>
   </style:style>
   <style:style style:name="T20" style:family="text">
    <style:text-properties style:font-name="Gill Sans MT"/>
@@ -4428,9 +4430,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:user-field-decl office:value-type="float" office:value="1" text:name="MD"/>
     <text:user-field-decl office:value-type="string" office:string-value="" text:name="SEQ CHAPTER \h   1"/>
    </text:user-field-decls>
-   <text:p text:style-name="P67"/>
+   <text:p text:style-name="P66"/>
    <text:section text:style-name="Sect1" text:name="FOAMOPTS">
-    <text:h text:style-name="P34" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc224982_3519154785"/>FOAMOPTS - Define Foam Model Options<text:bookmark-end text:name="__RefHeading___Toc224982_3519154785"/></text:h>
+    <text:h text:style-name="P44" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc224982_3519154785"/>FOAMOPTS - Define Foam Model Options<text:bookmark-end text:name="__RefHeading___Toc224982_3519154785"/></text:h>
     <table:table table:name="Table971" table:style-name="Table971">
      <table:table-column table:style-name="Table971.A" table:number-columns-repeated="4"/>
      <table:table-column table:style-name="Table971.E"/>
@@ -4463,9 +4465,8 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       </table:table-cell>
      </table:table-row>
     </table:table>
-    <text:h text:style-name="P38" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc32167_370116838837"/>Description<text:bookmark-end text:name="__RefHeading___Toc32167_370116838837"/></text:h>
+    <text:h text:style-name="P48" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc32167_370116838837"/>Description<text:bookmark-end text:name="__RefHeading___Toc32167_370116838837"/></text:h>
     <text:p text:style-name="_40_TextBody">The <text:span text:style-name="T26">FOAMOPTS</text:span> keyword defines the <text:span text:style-name="T26">transport phase for the foam (gas or water) and how gas mobility reduction should be calculated for when the Foam option has been activated by the FOAM keyword in the RUNSPEC section.</text:span></text:p>
-    <text:p text:style-name="_40_TextBody"><text:span text:style-name="T16">The keyword is r</text:span><text:span text:style-name="T15">ecognized by the input deck parser and simulator support </text:span><text:span text:style-name="T17">is</text:span><text:span text:style-name="T15"> available in the experimental &quot;ebos&quot; simulator. </text:span></text:p>
     <table:table table:name="Table972" table:style-name="Table972">
      <table:table-column table:style-name="Table972.A"/>
      <table:table-column table:style-name="Table972.B"/>
@@ -4473,69 +4474,69 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      <table:table-column table:style-name="Table972.D"/>
      <table:table-row>
       <table:table-cell table:style-name="Table972.A1" office:value-type="string">
-       <text:p text:style-name="P30">No.</text:p>
+       <text:p text:style-name="P40">No.</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table972.A1" office:value-type="string">
-       <text:p text:style-name="P30">Name</text:p>
+       <text:p text:style-name="P40">Name</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table972.A1" office:value-type="string">
-       <text:p text:style-name="P30">Description</text:p>
+       <text:p text:style-name="P40">Description</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table972.D1" office:value-type="string">
-       <text:p text:style-name="P30">Default</text:p>
+       <text:p text:style-name="P40">Default</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table972.2">
       <table:table-cell table:style-name="Table972.A2" office:value-type="string">
-       <text:p text:style-name="P25">1</text:p>
+       <text:p text:style-name="P35">1</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table972.B2" office:value-type="string">
-       <text:p text:style-name="P26">FOAMOPT1</text:p>
+       <text:p text:style-name="P36">FOAMOPT1</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table972.C2" office:value-type="string">
-       <text:p text:style-name="P29">A <text:span text:style-name="T24">defined character that defines the transport phase for the foam, and should be </text:span>set to one of the following character strings:</text:p>
+       <text:p text:style-name="P39">A <text:span text:style-name="T24">defined character that defines the transport phase for the foam, and should be </text:span>set to one of the following character strings:</text:p>
        <text:list text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P68"><text:span text:style-name="T25">GAS</text:span>: <text:span text:style-name="T25">for the foam to be transport in the gas phase., or</text:span></text:p>
+         <text:p text:style-name="P67"><text:span text:style-name="T25">GAS</text:span>: <text:span text:style-name="T25">for the foam to be transport in the gas phase., or</text:span></text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P69">WAT<text:span text:style-name="T27">ER</text:span>: for <text:span text:style-name="T27">the foam to be transported in the water phase.</text:span> </text:p>
+         <text:p text:style-name="P68">WAT<text:span text:style-name="T27">ER</text:span>: for <text:span text:style-name="T27">the foam to be transported in the water phase.</text:span> </text:p>
         </text:list-item>
        </text:list>
       </table:table-cell>
       <table:table-cell table:style-name="Table972.D2" office:value-type="string">
-       <text:p text:style-name="P28">GAS</text:p>
+       <text:p text:style-name="P38">GAS</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table972.2">
-      <table:table-cell table:style-name="Table972.A2" office:value-type="string">
-       <text:p text:style-name="P25">2</text:p>
+      <table:table-cell table:style-name="Table972.A3" office:value-type="string">
+       <text:p text:style-name="P35">2</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table972.B2" office:value-type="string">
-       <text:p text:style-name="P26">FOAMOPT2</text:p>
+       <text:p text:style-name="P36">FOAMOPT2</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table972.C2" office:value-type="string">
-       <text:p text:style-name="P29">A <text:span text:style-name="T24">defined character that defines the method to be used to calculated the reduction in gas mobility, and should be </text:span>set to one of the following character strings:</text:p>
+       <text:p text:style-name="P39">A <text:span text:style-name="T24">defined character that defines the method to be used to calculated the reduction in gas mobility, and should be </text:span>set to one of the following character strings:</text:p>
        <text:list text:continue-numbering="true" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P68"><text:span text:style-name="T27">TAB</text:span>: <text:span text:style-name="T27">Sets the reduction in gas mobility to be calculated based on tables using the FOAMMOD keyword as a function of foam concentration, the FOAMMOBS as a function for shear, or as a function of pressure using the FOAMMOBP keyword. All keywords are in the PROPS section.</text:span></text:p>
+         <text:p text:style-name="P67"><text:span text:style-name="T27">TAB</text:span>: <text:span text:style-name="T27">Sets the reduction in gas mobility to be calculated based on tables using the FOAMMOD keyword as a function of foam concentration, the FOAMMOBS as a function for shear, or as a function of pressure using the FOAMMOBP keyword. All keywords are in the PROPS section.</text:span></text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P69"><text:span text:style-name="T27">FUNC</text:span>: <text:s/><text:span text:style-name="T27">Sets the reduction in gas mobility to be calculated based on a function defined via the FOAMFRM, FOAMFSC, FOAMFSW, FOAMFSO, FOAMFCN, or FOAMFST keywords in the PROPS section. Note this option is not supported by OPM Flow.</text:span></text:p>
+         <text:p text:style-name="P68"><text:span text:style-name="T27">FUNC</text:span>: <text:s/><text:span text:style-name="T27">Sets the reduction in gas mobility to be calculated based on a function defined via the FOAMFRM, FOAMFSC, FOAMFSW, FOAMFSO, FOAMFCN, or FOAMFST keywords in the PROPS section. Note this option is not supported by OPM Flow.</text:span></text:p>
         </text:list-item>
        </text:list>
-       <text:p text:style-name="P27">Only the default value of TAB is currently supported by OPM Flow.</text:p>
+       <text:p text:style-name="P37">Only the default value of TAB is currently supported by OPM Flow.</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table972.D2" office:value-type="string">
-       <text:p text:style-name="P28">TAB</text:p>
+       <text:p text:style-name="P38">TAB</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row>
       <table:table-cell table:style-name="Table972.A4" table:number-columns-spanned="4" office:value-type="string">
-       <text:p text:style-name="P24">Notes:</text:p>
+       <text:p text:style-name="P34">Notes:</text:p>
        <text:list text:style-name="L1">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P70"><text:span text:style-name="T22">T</text:span><text:span text:style-name="T23">he keyword is terminated by a “/”.</text:span></text:p>
+         <text:p text:style-name="P69"><text:span text:style-name="T22">T</text:span><text:span text:style-name="T23">he keyword is terminated by a “/”.</text:span></text:p>
         </text:list-item>
        </text:list>
       </table:table-cell>
@@ -4544,18 +4545,18 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
      </table:table-row>
     </table:table>
-    <text:p text:style-name="P33">Table <text:sequence text:ref-name="refTable0" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">8.3.70.1</text:sequence>: <text:span text:style-name="T26">FOAMOPTS Keyword Description</text:span></text:p>
-    <text:p text:style-name="P31"/>
-    <text:h text:style-name="P38" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc32169_370116838835"/>Example<text:bookmark-end text:name="__RefHeading___Toc32169_370116838835"/></text:h>
-    <text:p text:style-name="P32">--</text:p>
-    <text:p text:style-name="P32">-- <text:s text:c="6"/>FOAMOPT1 <text:s/>FOAMOPT2 <text:s text:c="62"/></text:p>
-    <text:p text:style-name="P32">-- <text:s text:c="6"/>PHASE <text:s text:c="4"/>MOBILITY <text:s text:c="60"/></text:p>
-    <text:p text:style-name="P32">-- <text:s text:c="6"/>-------- <text:s/>-------- <text:s text:c="59"/></text:p>
-    <text:p text:style-name="P32">FOAMOPTS <text:s text:c="74"/></text:p>
-    <text:p text:style-name="P32"><text:s text:c="9"/>GAS <text:s text:c="6"/>TAB <text:s text:c="36"/>/ FOAM MODEL OPTIONS <text:s text:c="9"/></text:p>
-    <text:p text:style-name="P31"/>
-    <text:p text:style-name="P36">The above example defines the transport phase to be gas and the gas mobility reduction to use a table as defined by the FOAMMOD keyword as a function of foam concentration, the FOAMMOBS as a function of shear, or as a function of pressure using the FOAMMOBP keyword. </text:p>
-    <text:p text:style-name="P35"/>
+    <text:p text:style-name="P43">Table <text:sequence text:ref-name="refTable0" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">8.3.70.1</text:sequence>: <text:span text:style-name="T26">FOAMOPTS Keyword Description</text:span></text:p>
+    <text:p text:style-name="P41"/>
+    <text:h text:style-name="P48" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc32169_370116838835"/>Example<text:bookmark-end text:name="__RefHeading___Toc32169_370116838835"/></text:h>
+    <text:p text:style-name="P42">--</text:p>
+    <text:p text:style-name="P42">-- <text:s text:c="6"/>FOAMOPT1 <text:s/>FOAMOPT2 <text:s text:c="62"/></text:p>
+    <text:p text:style-name="P42">-- <text:s text:c="6"/>PHASE <text:s text:c="4"/>MOBILITY <text:s text:c="60"/></text:p>
+    <text:p text:style-name="P42">-- <text:s text:c="6"/>-------- <text:s/>-------- <text:s text:c="59"/></text:p>
+    <text:p text:style-name="P42">FOAMOPTS <text:s text:c="74"/></text:p>
+    <text:p text:style-name="P42"><text:s text:c="9"/>GAS <text:s text:c="6"/>TAB <text:s text:c="36"/>/ FOAM MODEL OPTIONS <text:s text:c="9"/></text:p>
+    <text:p text:style-name="P41"/>
+    <text:p text:style-name="P46">The above example defines the transport phase to be gas and the gas mobility reduction to use a table as defined by the FOAMMOD keyword as a function of foam concentration, the FOAMMOBS as a function of shear, or as a function of pressure using the FOAMMOBP keyword. </text:p>
+    <text:p text:style-name="P45"/>
    </text:section>
   </office:text>
  </office:body>


### PR DESCRIPTION
Added support for modeling foam (FOAM) plus solvent (SOLVENT) in the simulator (#4654, #3523 and #805). In addition, gas or water is now allowed as the transport phase for the foam as specified by FOAMOPTS item 1 (previously only gas was supported as the foam transport phase).