### PR TITLE
Update GCONPROD for 2023-10

### DIFF
--- a/parts/chapters/subsections/12.3/GCONPROD.fodt
+++ b/parts/chapters/subsections/12.3/GCONPROD.fodt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:officeooo="http://openoffice.org/2009/office" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
- <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT5H50M6S</meta:editing-duration><meta:editing-cycles>28</meta:editing-cycles><meta:generator>LibreOffice/7.6.2.1$Windows_X86_64 LibreOffice_project/56f7684011345957bbf33a7ee678afaf4d2ba333</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
+ <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT5H51M32S</meta:editing-duration><meta:editing-cycles>29</meta:editing-cycles><meta:generator>LibreOffice/7.6.2.1$Windows_X86_64 LibreOffice_project/56f7684011345957bbf33a7ee678afaf4d2ba333</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
 1) eq 
 2) F3
 
@@ -17,24 +17,24 @@ To insert a new keyword section (except for the header
 To insert standard text:
 1) t0, t1, t2
 2) F3
-Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:initial-creator>David Baxendale</meta:initial-creator><dc:date>2023-12-19T12:26:34.750000000</dc:date><meta:document-statistic meta:table-count="9" meta:image-count="0" meta:object-count="0" meta:page-count="6" meta:paragraph-count="265" meta:word-count="2204" meta:character-count="13116" meta:non-whitespace-character-count="10550"/><meta:user-defined meta:name="ClientContact">ClientContact</meta:user-defined><meta:user-defined meta:name="ClientEmail">ClientEmail</meta:user-defined><meta:user-defined meta:name="ClientName">Equinor ASA</meta:user-defined><meta:user-defined meta:name="ClientOffice">ClientOfficeAddres</meta:user-defined><meta:user-defined meta:name="ClientRegistered" meta:value-type="string">ClientRegisteredAddress</meta:user-defined><meta:user-defined meta:name="ClientTelNo" meta:value-type="string">ClientTelNo</meta:user-defined><meta:user-defined meta:name="DocumentDate" meta:value-type="string">June 8, 2023</meta:user-defined><meta:user-defined meta:name="DocumentNumber" meta:value-type="string">2023-04-RPT</meta:user-defined><meta:user-defined meta:name="DocumentRevision" meta:value-type="string">Rev-0</meta:user-defined><meta:user-defined meta:name="ProgramVersion" meta:value-type="string">2023-04</meta:user-defined></office:meta>
+Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:initial-creator>David Baxendale</meta:initial-creator><dc:date>2024-01-02T13:56:41.142000000</dc:date><meta:document-statistic meta:table-count="9" meta:image-count="0" meta:object-count="0" meta:page-count="6" meta:paragraph-count="265" meta:word-count="2200" meta:character-count="13100" meta:non-whitespace-character-count="10538"/><meta:user-defined meta:name="ClientContact">ClientContact</meta:user-defined><meta:user-defined meta:name="ClientEmail">ClientEmail</meta:user-defined><meta:user-defined meta:name="ClientName">Equinor ASA</meta:user-defined><meta:user-defined meta:name="ClientOffice">ClientOfficeAddres</meta:user-defined><meta:user-defined meta:name="ClientRegistered" meta:value-type="string">ClientRegisteredAddress</meta:user-defined><meta:user-defined meta:name="ClientTelNo" meta:value-type="string">ClientTelNo</meta:user-defined><meta:user-defined meta:name="DocumentDate" meta:value-type="string">June 8, 2023</meta:user-defined><meta:user-defined meta:name="DocumentNumber" meta:value-type="string">2023-04-RPT</meta:user-defined><meta:user-defined meta:name="DocumentRevision" meta:value-type="string">Rev-0</meta:user-defined><meta:user-defined meta:name="ProgramVersion" meta:value-type="string">2023-04</meta:user-defined></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
-   <config:config-item config:name="ViewAreaTop" config:type="long">137492</config:config-item>
+   <config:config-item config:name="ViewAreaTop" config:type="long">118874</config:config-item>
    <config:config-item config:name="ViewAreaLeft" config:type="long">0</config:config-item>
    <config:config-item config:name="ViewAreaWidth" config:type="long">26460</config:config-item>
-   <config:config-item config:name="ViewAreaHeight" config:type="long">29700</config:config-item>
+   <config:config-item config:name="ViewAreaHeight" config:type="long">29065</config:config-item>
    <config:config-item config:name="ShowRedlineChanges" config:type="boolean">true</config:config-item>
    <config:config-item config:name="InBrowseMode" config:type="boolean">false</config:config-item>
    <config:config-item-map-indexed config:name="Views">
     <config:config-item-map-entry>
      <config:config-item config:name="ViewId" config:type="string">view2</config:config-item>
-     <config:config-item config:name="ViewLeft" config:type="long">14647</config:config-item>
-     <config:config-item config:name="ViewTop" config:type="long">135386</config:config-item>
+     <config:config-item config:name="ViewLeft" config:type="long">13201</config:config-item>
+     <config:config-item config:name="ViewTop" config:type="long">127665</config:config-item>
      <config:config-item config:name="VisibleLeft" config:type="long">0</config:config-item>
-     <config:config-item config:name="VisibleTop" config:type="long">137492</config:config-item>
+     <config:config-item config:name="VisibleTop" config:type="long">118874</config:config-item>
      <config:config-item config:name="VisibleRight" config:type="long">26458</config:config-item>
-     <config:config-item config:name="VisibleBottom" config:type="long">167190</config:config-item>
+     <config:config-item config:name="VisibleBottom" config:type="long">147937</config:config-item>
      <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutColumns" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutBookMode" config:type="boolean">false</config:config-item>
@@ -116,7 +116,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <config:config-item config:name="LoadReadonly" config:type="boolean">false</config:config-item>
    <config:config-item config:name="ClipAsCharacterAnchoredWriterFlyFrames" config:type="boolean">false</config:config-item>
    <config:config-item config:name="UseOldPrinterMetrics" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="Rsid" config:type="int">2023851</config:config-item>
+   <config:config-item config:name="Rsid" config:type="int">2115462</config:config-item>
    <config:config-item config:name="RsidRoot" config:type="int">130112</config:config-item>
    <config:config-item config:name="ProtectForm" config:type="boolean">false</config:config-item>
    <config:config-item config:name="MsWordCompTrailingBlanks" config:type="boolean">false</config:config-item>
@@ -508,7 +508,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
   </draw:fill-image>
   <style:default-style style:family="graphic">
    <style:graphic-properties svg:stroke-color="#000000" draw:fill-color="#99ccff" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.3cm" draw:shadow-offset-y="0.3cm" draw:start-line-spacing-horizontal="0.283cm" draw:start-line-spacing-vertical="0.283cm" draw:end-line-spacing-horizontal="0.283cm" draw:end-line-spacing-vertical="0.283cm" style:writing-mode="lr-tb" style:flow-with-text="false"/>
-   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0cm" style:font-independent-line-spacing="false">
+   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0cm" style:writing-mode="lr-tb" style:font-independent-line-spacing="false">
     <style:tab-stops/>
    </style:paragraph-properties>
    <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Times New Roman1" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="DejaVu Sans" style:font-size-asian="12pt" style:language-asian="zxx" style:country-asian="none" style:font-name-complex="Lucidasans1" style:font-size-complex="12pt" style:language-complex="zxx" style:country-complex="none"/>
@@ -5379,7 +5379,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
         </text:list-item>
        </text:list>
        <text:p text:style-name="P128">The corrective action takes places at the end of the time step in which the constraint is violated.</text:p>
-       <text:p text:style-name="P128">Note that the only the NONE and RATE options are currently supported by the simulator.</text:p>
+       <text:p text:style-name="P128">Note that only the NONE and RATE options are currently supported by the simulator.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
@@ -5513,7 +5513,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
         </text:list-item>
        </text:list>
        <text:p text:style-name="P128">If defaulted then procedure defined by ACTION, item (7), is applied. <text:s/>The corrective action takes places at the end of the time step in which the constraint is violated.</text:p>
-       <text:p text:style-name="P128">Note that the only the NONE and RATE options are currently supported by the simulator.</text:p>
+       <text:p text:style-name="P128">Note that only the NONE and RATE options are currently supported by the simulator.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
@@ -5551,7 +5551,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
         </text:list-item>
        </text:list>
        <text:p text:style-name="P128">If defaulted then procedure defined by ACTION, item (7), is applied. <text:s/>The corrective action takes places at the end of the time step in which the constraint is violated</text:p>
-       <text:p text:style-name="P128">Note that the only the NONE and RATE options are currently supported by the simulator.</text:p>
+       <text:p text:style-name="P128">Note that only the NONE and RATE options are currently supported by the simulator.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
@@ -5590,7 +5590,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
         </text:list-item>
        </text:list>
        <text:p text:style-name="P128">If defaulted then procedure defined by ACTION, item (7), is applied. <text:s/>The corrective action takes places at the end of the time step in which the constraint is violated.</text:p>
-       <text:p text:style-name="P128">Note that the only the NONE and RATE options are currently supported by the simulator.</text:p>
+       <text:p text:style-name="P128">Note that only the NONE and RATE options are currently supported by the simulator.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>


### PR DESCRIPTION
(1) Added support for GCONPROD item 7 ACTION equal to NONE in the SCHEDULE section, which specifies that no action is to be taken if the oil, water, gas or liquid rate constraints are violated. Previously only the RATE option was supported by the simulator. (2) Added partial support for setting items 11, 12 and 13 of GCONPROD in the SCHEDULE section: ACTWAT, ACTGAS and ACTLIQ respectively define the action to be taken if the water rate (WRAT), gas rate (GRAT) and liquid rate (LRAT) constraints defined by GCONPROD are violated. Supported options are now NONE or RATE. Options CON, +CON, WELL, and PLUG are not currently supported (#4748).