### PR TITLE
Update WPAVE for 2023-10

### DIFF
--- a/parts/chapters/subsections/12.3/WPAVE.fodt
+++ b/parts/chapters/subsections/12.3/WPAVE.fodt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:officeooo="http://openoffice.org/2009/office" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
- <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT6H16M9S</meta:editing-duration><meta:editing-cycles>25</meta:editing-cycles><meta:generator>LibreOffice/7.6.2.1$Windows_X86_64 LibreOffice_project/56f7684011345957bbf33a7ee678afaf4d2ba333</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
+ <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT6H15M27S</meta:editing-duration><meta:editing-cycles>24</meta:editing-cycles><meta:generator>LibreOffice/7.6.2.1$Windows_X86_64 LibreOffice_project/56f7684011345957bbf33a7ee678afaf4d2ba333</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
 1) eq 
 2) F3
 
@@ -17,24 +17,24 @@ To insert a new keyword section (except for the header
 To insert standard text:
 1) t0, t1, t2
 2) F3
-Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:initial-creator>David Baxendale</meta:initial-creator><dc:date>2023-12-12T15:04:51.875000000</dc:date><meta:document-statistic meta:table-count="9" meta:image-count="0" meta:object-count="0" meta:page-count="3" meta:paragraph-count="136" meta:word-count="834" meta:character-count="5587" meta:non-whitespace-character-count="4069"/><meta:user-defined meta:name="ClientContact">ClientContact</meta:user-defined><meta:user-defined meta:name="ClientEmail">ClientEmail</meta:user-defined><meta:user-defined meta:name="ClientName">Equinor ASA</meta:user-defined><meta:user-defined meta:name="ClientOffice">ClientOfficeAddres</meta:user-defined><meta:user-defined meta:name="ClientRegistered" meta:value-type="string">ClientRegisteredAddress</meta:user-defined><meta:user-defined meta:name="ClientTelNo" meta:value-type="string">ClientTelNo</meta:user-defined><meta:user-defined meta:name="DocumentDate" meta:value-type="string">June 8, 2023</meta:user-defined><meta:user-defined meta:name="DocumentNumber" meta:value-type="string">2023-04-RPT</meta:user-defined><meta:user-defined meta:name="DocumentRevision" meta:value-type="string">Rev-0</meta:user-defined><meta:user-defined meta:name="ProgramVersion" meta:value-type="string">2023-04</meta:user-defined></office:meta>
+Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:initial-creator>David Baxendale</meta:initial-creator><dc:date>2023-12-12T11:02:13.154000000</dc:date><meta:document-statistic meta:table-count="9" meta:image-count="0" meta:object-count="0" meta:page-count="3" meta:paragraph-count="136" meta:word-count="824" meta:character-count="5503" meta:non-whitespace-character-count="3995"/><meta:user-defined meta:name="ClientContact">ClientContact</meta:user-defined><meta:user-defined meta:name="ClientEmail">ClientEmail</meta:user-defined><meta:user-defined meta:name="ClientName">Equinor ASA</meta:user-defined><meta:user-defined meta:name="ClientOffice">ClientOfficeAddres</meta:user-defined><meta:user-defined meta:name="ClientRegistered" meta:value-type="string">ClientRegisteredAddress</meta:user-defined><meta:user-defined meta:name="ClientTelNo" meta:value-type="string">ClientTelNo</meta:user-defined><meta:user-defined meta:name="DocumentDate" meta:value-type="string">June 8, 2023</meta:user-defined><meta:user-defined meta:name="DocumentNumber" meta:value-type="string">2023-04-RPT</meta:user-defined><meta:user-defined meta:name="DocumentRevision" meta:value-type="string">Rev-0</meta:user-defined><meta:user-defined meta:name="ProgramVersion" meta:value-type="string">2023-04</meta:user-defined></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
-   <config:config-item config:name="ViewAreaTop" config:type="long">54716</config:config-item>
+   <config:config-item config:name="ViewAreaTop" config:type="long">32914</config:config-item>
    <config:config-item config:name="ViewAreaLeft" config:type="long">0</config:config-item>
    <config:config-item config:name="ViewAreaWidth" config:type="long">21500</config:config-item>
-   <config:config-item config:name="ViewAreaHeight" config:type="long">24370</config:config-item>
+   <config:config-item config:name="ViewAreaHeight" config:type="long">23855</config:config-item>
    <config:config-item config:name="ShowRedlineChanges" config:type="boolean">true</config:config-item>
    <config:config-item config:name="InBrowseMode" config:type="boolean">false</config:config-item>
    <config:config-item-map-indexed config:name="Views">
     <config:config-item-map-entry>
      <config:config-item config:name="ViewId" config:type="string">view2</config:config-item>
-     <config:config-item config:name="ViewLeft" config:type="long">11137</config:config-item>
-     <config:config-item config:name="ViewTop" config:type="long">71049</config:config-item>
+     <config:config-item config:name="ViewLeft" config:type="long">4583</config:config-item>
+     <config:config-item config:name="ViewTop" config:type="long">38691</config:config-item>
      <config:config-item config:name="VisibleLeft" config:type="long">0</config:config-item>
-     <config:config-item config:name="VisibleTop" config:type="long">54716</config:config-item>
+     <config:config-item config:name="VisibleTop" config:type="long">32914</config:config-item>
      <config:config-item config:name="VisibleRight" config:type="long">21498</config:config-item>
-     <config:config-item config:name="VisibleBottom" config:type="long">79084</config:config-item>
+     <config:config-item config:name="VisibleBottom" config:type="long">56767</config:config-item>
      <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutColumns" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutBookMode" config:type="boolean">false</config:config-item>
@@ -116,7 +116,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <config:config-item config:name="LoadReadonly" config:type="boolean">false</config:config-item>
    <config:config-item config:name="ClipAsCharacterAnchoredWriterFlyFrames" config:type="boolean">false</config:config-item>
    <config:config-item config:name="UseOldPrinterMetrics" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="Rsid" config:type="int">1932416</config:config-item>
+   <config:config-item config:name="Rsid" config:type="int">1867023</config:config-item>
    <config:config-item config:name="RsidRoot" config:type="int">130112</config:config-item>
    <config:config-item config:name="ProtectForm" config:type="boolean">false</config:config-item>
    <config:config-item config:name="MsWordCompTrailingBlanks" config:type="boolean">false</config:config-item>
@@ -508,7 +508,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
   </draw:fill-image>
   <style:default-style style:family="graphic">
    <style:graphic-properties svg:stroke-color="#000000" draw:fill-color="#99ccff" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.3cm" draw:shadow-offset-y="0.3cm" draw:start-line-spacing-horizontal="0.283cm" draw:start-line-spacing-vertical="0.283cm" draw:end-line-spacing-horizontal="0.283cm" draw:end-line-spacing-vertical="0.283cm" style:writing-mode="lr-tb" style:flow-with-text="false"/>
-   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0cm" style:writing-mode="lr-tb" style:font-independent-line-spacing="false">
+   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0cm" style:font-independent-line-spacing="false">
     <style:tab-stops/>
    </style:paragraph-properties>
    <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Times New Roman1" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="DejaVu Sans" style:font-size-asian="12pt" style:language-asian="zxx" style:country-asian="none" style:font-name-complex="Lucidasans1" style:font-size-complex="12pt" style:language-complex="zxx" style:country-complex="none"/>
@@ -997,15 +997,15 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:graphic-properties>
   </style:style>
   <style:style style:name="Frame" style:family="graphic">
-   <style:graphic-properties svg:width="17.189cm" fo:min-width="60%" svg:height="14.848cm" fo:min-height="56%" text:anchor-type="paragraph" svg:x="2.702cm" svg:y="0cm" fo:margin-left="0.508cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:run-through="foreground" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph-content" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" fo:background-color="transparent" draw:fill="none" fo:padding="0.152cm" fo:border="0.06pt solid #000000" style:shadow="#000000 0.178cm 0.178cm" draw:shadow-opacity="100%" loext:rel-width-rel="paragraph" loext:rel-height-rel="paragraph">
+   <style:graphic-properties svg:width="17.189cm" fo:min-width="60%" svg:height="14.848cm" fo:min-height="56%" text:anchor-type="paragraph" svg:x="2.702cm" svg:y="0cm" fo:margin-left="0.508cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:run-through="foreground" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph-content" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" draw:fill="none" fo:padding="0.152cm" fo:border="0.06pt solid #000000" style:shadow="#000000 0.178cm 0.178cm" draw:shadow-opacity="100%" loext:rel-width-rel="paragraph" loext:rel-height-rel="paragraph">
     <style:columns fo:column-count="1" fo:column-gap="0cm"/>
    </style:graphic-properties>
   </style:style>
   <style:style style:name="Formula" style:family="graphic">
-   <style:graphic-properties text:anchor-type="as-char" svg:y="0cm" fo:margin-left="0.051cm" fo:margin-right="0.051cm" style:wrap="parallel" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="middle" style:vertical-rel="text" fo:background-color="transparent" draw:fill="none" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true"/>
+   <style:graphic-properties text:anchor-type="as-char" svg:y="0cm" fo:margin-left="0.051cm" fo:margin-right="0.051cm" style:wrap="parallel" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="middle" style:vertical-rel="text" draw:fill="none" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true"/>
   </style:style>
   <style:style style:name="OLE" style:family="graphic">
-   <style:graphic-properties text:anchor-type="paragraph" svg:x="0cm" svg:y="0cm" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" fo:background-color="transparent" draw:fill="none"/>
+   <style:graphic-properties text:anchor-type="paragraph" svg:x="0cm" svg:y="0cm" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" draw:fill="none"/>
   </style:style>
   <text:outline-style style:name="Outline">
    <text:outline-level-style text:level="1" loext:num-list-format="CHAPTER %1%:" style:num-prefix="CHAPTER " style:num-suffix=":" style:num-format="1" text:start-value="12">
@@ -2655,72 +2655,10 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
   <style:style style:name="P22" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="00c150f8" officeooo:paragraph-rsid="00c150f8" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P23" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P24" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="01198236" officeooo:paragraph-rsid="01198236" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P25" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="011b2ab8" officeooo:paragraph-rsid="011b2ab8" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P26" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="small-caps" fo:color="#0066cc" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="16pt" fo:language="en" fo:country="US" fo:font-style="italic" officeooo:paragraph-rsid="002e95e7" style:font-name-asian="BernhardMod BT Roman" style:font-size-asian="16pt" style:font-style-asian="italic" style:font-name-complex="BernhardMod BT Roman" style:font-size-complex="16pt" style:font-style-complex="italic"/>
-  </style:style>
-  <style:style style:name="P27" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops>
-     <style:tab-stop style:position="10.795cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="14pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="06f8892a" style:font-size-asian="14pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="14pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P28" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="16pt" fo:language="en" fo:country="US" fo:font-style="italic" officeooo:paragraph-rsid="002e95e7" style:font-name-asian="BernhardMod BT Roman" style:font-size-asian="16pt" style:font-style-asian="italic" style:font-name-complex="BernhardMod BT Roman" style:font-size-complex="16pt" style:font-style-complex="italic"/>
-  </style:style>
-  <style:style style:name="P29" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops>
-     <style:tab-stop style:position="10.795cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Cabin" fo:font-size="14pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="14pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="14pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P30" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops>
-     <style:tab-stop style:position="10.795cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="12pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="12pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="12pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P31" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
-    <style:tab-stops/>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="12pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001a71eb" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="12pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="12pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P32" style:family="paragraph" style:parent-style-name="Standard">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:writing-mode="page"/>
    <style:text-properties fo:font-size="6pt" fo:language="en" fo:country="US" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="5.25pt" style:font-size-complex="6pt"/>
   </style:style>
-  <style:style style:name="P33" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
+  <style:style style:name="P23" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
    <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
     <style:tab-stops>
@@ -2730,60 +2668,55 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P34" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P24" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
    <style:text-properties fo:language="en" fo:country="US" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="00531151" officeooo:paragraph-rsid="06dac430" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
-  <style:style style:name="P35" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P25" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06db8512" officeooo:paragraph-rsid="06db8512"/>
   </style:style>
-  <style:style style:name="P36" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P26" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06db8512" officeooo:paragraph-rsid="06db8512"/>
   </style:style>
-  <style:style style:name="P37" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P27" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06db8512" officeooo:paragraph-rsid="06db8512"/>
   </style:style>
-  <style:style style:name="P38" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06db8512" officeooo:paragraph-rsid="001c7d0f"/>
-  </style:style>
-  <style:style style:name="P39" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P28" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="06dac430"/>
   </style:style>
-  <style:style style:name="P40" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P29" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="06db8512"/>
   </style:style>
-  <style:style style:name="P41" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P30" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06a03e71" officeooo:paragraph-rsid="06dac430"/>
   </style:style>
-  <style:style style:name="P42" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P31" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06dd3088" officeooo:paragraph-rsid="06dd3088"/>
   </style:style>
-  <style:style style:name="P43" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P32" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06dd3088" officeooo:paragraph-rsid="06dd3088"/>
   </style:style>
-  <style:style style:name="P44" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P33" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06dd3088" officeooo:paragraph-rsid="06dd3088"/>
   </style:style>
-  <style:style style:name="P45" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P34" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -2793,66 +2726,66 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06dd3088" officeooo:paragraph-rsid="06dd3088"/>
   </style:style>
-  <style:style style:name="P46" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P35" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="004069ac" officeooo:paragraph-rsid="06dac430"/>
   </style:style>
-  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P36" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062cbd9a" officeooo:paragraph-rsid="06dac430"/>
   </style:style>
-  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P37" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062cbd9a" officeooo:paragraph-rsid="06db8512"/>
   </style:style>
-  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Table_20_Heading">
+  <style:style style:name="P38" style:family="paragraph" style:parent-style-name="Table_20_Heading">
    <style:text-properties fo:language="en" fo:country="US"/>
   </style:style>
-  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P39" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" style:text-underline-style="none" officeooo:rsid="05a3970b" officeooo:paragraph-rsid="0e5cbefd"/>
   </style:style>
-  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P40" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="063c3886" officeooo:paragraph-rsid="06dd407a"/>
   </style:style>
-  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P41" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="00c4ec6d" officeooo:paragraph-rsid="13d8a0f1"/>
   </style:style>
-  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P42" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06dd407a" officeooo:paragraph-rsid="06dac430"/>
   </style:style>
-  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="_40_Example">
+  <style:style style:name="P43" style:family="paragraph" style:parent-style-name="_40_Example">
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06dd407a" officeooo:paragraph-rsid="06dd407a"/>
   </style:style>
-  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P44" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="06dd407a"/>
   </style:style>
-  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="_40_Example">
+  <style:style style:name="P45" style:family="paragraph" style:parent-style-name="_40_Example">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="06dd407a"/>
   </style:style>
-  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="Table">
+  <style:style style:name="P46" style:family="paragraph" style:parent-style-name="Table">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="06dac430"/>
   </style:style>
-  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Standard">
+  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Standard">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="06dac430"/>
   </style:style>
-  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Heading_20_4">
+  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Heading_20_4">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="06dac430"/>
   </style:style>
-  <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Heading_20_3">
+  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Heading_20_3">
    <style:paragraph-properties fo:break-before="page"/>
    <style:text-properties fo:language="en" fo:country="US"/>
   </style:style>
-  <style:style style:name="P61" style:family="paragraph" style:parent-style-name="Heading_20_4">
+  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Heading_20_4">
    <style:text-properties fo:language="en" fo:country="US"/>
   </style:style>
-  <style:style style:name="P62" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="05c7f16b" officeooo:paragraph-rsid="06dac430"/>
   </style:style>
-  <style:style style:name="P63" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -2862,10 +2795,87 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06305dda" officeooo:paragraph-rsid="06dd3088"/>
   </style:style>
-  <style:style style:name="P64" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="07876263" officeooo:paragraph-rsid="001c7d0f"/>
+  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="Footer">
+   <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
+    <style:tab-stops>
+     <style:tab-stop style:position="8.498cm" style:type="center"/>
+     <style:tab-stop style:position="16.999cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="07061c8d" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
+    <style:tab-stops>
+     <style:tab-stop style:position="8.498cm" style:type="center"/>
+     <style:tab-stop style:position="16.999cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="00c150f8" officeooo:paragraph-rsid="00c150f8" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="01198236" officeooo:paragraph-rsid="01198236" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:color="#ffffff" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="17pt" fo:language="en" fo:country="US" fo:font-weight="bold" officeooo:rsid="011b2ab8" officeooo:paragraph-rsid="011b2ab8" style:font-size-asian="17pt" style:font-weight-asian="bold" style:font-size-complex="17pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="10.795cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="12pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="12pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="12pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="12pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001a71eb" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="12pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="12pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P61" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="10.795cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="14pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="06f8892a" style:font-size-asian="14pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="14pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P62" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="16pt" fo:language="en" fo:country="US" fo:font-style="italic" officeooo:paragraph-rsid="002e95e7" style:font-name-asian="BernhardMod BT Roman" style:font-size-asian="16pt" style:font-style-asian="italic" style:font-name-complex="BernhardMod BT Roman" style:font-size-complex="16pt" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="P63" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.009cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="10.795cm" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="small-caps" fo:color="#000000" loext:opacity="100%" style:font-name="Cabin" fo:font-size="14pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b50a2" officeooo:paragraph-rsid="002e95e7" style:font-size-asian="14pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="14pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P64" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="small-caps" fo:color="#0066cc" loext:opacity="100%" style:font-name="Gill Sans MT" fo:font-size="16pt" fo:language="en" fo:country="US" fo:font-style="italic" officeooo:paragraph-rsid="002e95e7" style:font-name-asian="BernhardMod BT Roman" style:font-size-asian="16pt" style:font-style-asian="italic" style:font-name-complex="BernhardMod BT Roman" style:font-size-complex="16pt" style:font-style-complex="italic"/>
   </style:style>
   <style:style style:name="P65" style:family="paragraph" style:parent-style-name="_40_Table_20_Contents">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
@@ -2894,83 +2904,74 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" fo:language="en" fo:country="US" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
-  <style:style style:name="P72" style:family="paragraph" style:parent-style-name="Footer">
-   <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
-    <style:tab-stops>
-     <style:tab-stop style:position="8.498cm" style:type="center"/>
-     <style:tab-stop style:position="16.999cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="07061c8d" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P73" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
-    <style:tab-stops>
-     <style:tab-stop style:position="8.498cm" style:type="center"/>
-     <style:tab-stop style:position="16.999cm" style:type="right"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P74" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P72" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties officeooo:rsid="003d1478" officeooo:paragraph-rsid="06dac430"/>
   </style:style>
-  <style:style style:name="P75" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P73" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="06dac430"/>
   </style:style>
-  <style:style style:name="P76" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P74" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties officeooo:paragraph-rsid="13d8a0f1"/>
   </style:style>
-  <style:style style:name="P77" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+  <style:style style:name="P75" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
    <style:paragraph-properties style:page-number="auto"/>
   </style:style>
-  <style:style style:name="P78" style:family="paragraph" style:parent-style-name="Standard">
+  <style:style style:name="P76" style:family="paragraph" style:parent-style-name="Standard">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="100%" fo:text-align="start" style:justify-single-word="false" fo:hyphenation-ladder-count="no-limit" fo:text-indent="0cm" style:auto-text-indent="false" style:text-autospace="ideograph-alpha" style:punctuation-wrap="hanging" style:line-break="strict" style:writing-mode="lr-tb">
     <style:tab-stops/>
    </style:paragraph-properties>
    <style:text-properties fo:hyphenate="false" fo:hyphenation-remain-char-count="2" fo:hyphenation-push-char-count="2" loext:hyphenation-no-caps="false" loext:hyphenation-no-last-word="false" loext:hyphenation-word-char-count="5" loext:hyphenation-zone="no-limit"/>
   </style:style>
-  <style:style style:name="P79" style:family="paragraph" style:parent-style-name="_40_TextBody">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P80" style:family="paragraph" style:parent-style-name="_40_Example">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P81" style:family="paragraph" style:parent-style-name="Table">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P82" style:family="paragraph" style:parent-style-name="Heading_20_3">
+  <style:style style:name="P77" style:family="paragraph" style:parent-style-name="Heading_20_3">
    <style:paragraph-properties fo:break-before="page"/>
    <style:text-properties fo:language="en" fo:country="US"/>
   </style:style>
-  <style:style style:name="P83" style:family="paragraph" style:parent-style-name="Heading_20_4">
+  <style:style style:name="P78" style:family="paragraph" style:parent-style-name="Heading_20_4">
    <style:text-properties fo:language="en" fo:country="US"/>
   </style:style>
-  <style:style style:name="P84" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="First_20_Page">
+  <style:style style:name="P79" style:family="paragraph" style:parent-style-name="Heading_20_4">
+   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="06dac430"/>
+  </style:style>
+  <style:style style:name="P80" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="First_20_Page">
    <style:paragraph-properties style:page-number="auto"/>
   </style:style>
-  <style:style style:name="P85" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties fo:language="en" fo:country="US"/>
+  <style:style style:name="P81" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06305dda" officeooo:paragraph-rsid="06dd3088"/>
   </style:style>
-  <style:style style:name="P86" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US"/>
+  <style:style style:name="P82" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06dd3088" officeooo:paragraph-rsid="06dd3088"/>
   </style:style>
-  <style:style style:name="P87" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:text-properties fo:language="en" fo:country="US"/>
+  <style:style style:name="P83" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="L1">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="05c7f16b" officeooo:paragraph-rsid="06dac430"/>
   </style:style>
-  <style:style style:name="P88" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
-   <style:paragraph-properties style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US"/>
+  <style:style style:name="P84" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06db8512" officeooo:paragraph-rsid="001c7d0f"/>
   </style:style>
-  <style:style style:name="P89" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="L1">
-   <style:text-properties fo:language="en" fo:country="US"/>
+  <style:style style:name="P85" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="07876263" officeooo:paragraph-rsid="001c7d0f"/>
   </style:style>
-  <style:style style:name="P90" style:family="paragraph">
+  <style:style style:name="P86" style:family="paragraph">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" fo:line-height="100%" fo:text-align="start" fo:text-indent="0cm" style:text-autospace="ideograph-alpha" style:punctuation-wrap="hanging" style:line-break="strict" loext:tab-stop-distance="0cm" style:writing-mode="lr-tb">
     <style:tab-stops/>
    </style:paragraph-properties>
@@ -3004,25 +3005,25 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <style:text-properties style:font-name="Gill Sans MT" officeooo:rsid="06f4e628"/>
   </style:style>
   <style:style style:name="T10" style:family="text">
-   <style:text-properties fo:font-size="20pt" style:font-size-asian="20pt" style:font-size-complex="20pt"/>
-  </style:style>
-  <style:style style:name="T11" style:family="text">
-   <style:text-properties fo:font-size="20pt" fo:font-style="normal" style:font-size-asian="20pt" style:font-style-asian="normal" style:font-size-complex="20pt" style:font-style-complex="normal"/>
-  </style:style>
-  <style:style style:name="T12" style:family="text">
-   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="20pt" fo:font-style="normal" style:font-size-asian="20pt" style:font-style-asian="normal" style:font-size-complex="20pt" style:font-style-complex="normal"/>
-  </style:style>
-  <style:style style:name="T13" style:family="text">
-   <style:text-properties officeooo:rsid="06f4e628"/>
-  </style:style>
-  <style:style style:name="T14" style:family="text">
-   <style:text-properties officeooo:rsid="07070fd2"/>
-  </style:style>
-  <style:style style:name="T15" style:family="text">
    <style:text-properties fo:language="en" fo:country="US"/>
   </style:style>
-  <style:style style:name="T16" style:family="text">
+  <style:style style:name="T11" style:family="text">
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="13ac3201"/>
+  </style:style>
+  <style:style style:name="T12" style:family="text">
+   <style:text-properties fo:font-size="20pt" style:font-size-asian="20pt" style:font-size-complex="20pt"/>
+  </style:style>
+  <style:style style:name="T13" style:family="text">
+   <style:text-properties fo:font-size="20pt" fo:font-style="normal" style:font-size-asian="20pt" style:font-style-asian="normal" style:font-size-complex="20pt" style:font-style-complex="normal"/>
+  </style:style>
+  <style:style style:name="T14" style:family="text">
+   <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="20pt" fo:font-style="normal" style:font-size-asian="20pt" style:font-style-asian="normal" style:font-size-complex="20pt" style:font-style-complex="normal"/>
+  </style:style>
+  <style:style style:name="T15" style:family="text">
+   <style:text-properties officeooo:rsid="06f4e628"/>
+  </style:style>
+  <style:style style:name="T16" style:family="text">
+   <style:text-properties officeooo:rsid="07070fd2"/>
   </style:style>
   <style:style style:name="T17" style:family="text">
    <style:text-properties style:font-name="Gill Sans MT"/>
@@ -4506,22 +4507,22 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:user-field-decl office:value-type="float" office:value="1" text:name="MD"/>
     <text:user-field-decl office:value-type="string" office:string-value="" text:name="SEQ CHAPTER \h   1"/>
    </text:user-field-decls>
-   <text:p text:style-name="P84"/>
+   <text:p text:style-name="P80"/>
    <text:section text:style-name="Sect1" text:name="WPAVE">
-    <text:h text:style-name="P60" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc121923_2556401936"/><office:annotation office:name="__Annotation__129131_843454886" loext:resolved="false">
+    <text:h text:style-name="P49" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc121923_2556401936"/><office:annotation office:name="__Annotation__129131_843454886" loext:resolved="false">
       <dc:creator>Atgeirr Rasmussen</dc:creator>
       <dc:date>2017-09-22T14:01:41.387549000</dc:date>
       <meta:creator-initials>AFR</meta:creator-initials>
-      <text:p text:style-name="P90"><text:span text:style-name="T39">Not supported. It is used on Norne, but investigations showed no significant effect so we did not implement it.</text:span></text:p>
-     </office:annotation>WPAVE<office:annotation-end office:name="__Annotation__129131_843454886"/><office:annotation loext:resolved="false">
+      <text:p text:style-name="P86"><text:span text:style-name="T39">Not supported. It is used on Norne, but investigations showed no significant effect so we did not implement it.</text:span></text:p>
+     </office:annotation><text:span text:style-name="T26">WPAVE</text:span><office:annotation-end office:name="__Annotation__129131_843454886"/><office:annotation loext:resolved="false">
       <dc:creator>David Baxendale</dc:creator>
       <dc:date>2017-10-03T12:19:22.164000000</dc:date>
       <meta:creator-initials>DBx</meta:creator-initials>
-      <text:p text:style-name="P90"><text:span text:style-name="T40">Reply to Atgeirr Rasmussen (09/22/2017, 14:01): &quot;...&quot;</text:span></text:p>
+      <text:p text:style-name="P86"><text:span text:style-name="T40">Reply to Atgeirr Rasmussen (09/22/2017, 14:01): &quot;...&quot;</text:span></text:p>
       <text:p><text:span text:style-name="T35">Okay, but if we done the work then perhaps we should implement it as it is one more feature we can say is implemented versus the commercial simulator. </text:span></text:p>
       <text:p><text:span text:style-name="T35"/></text:p>
       <text:p><text:span text:style-name="T35">Will change to not implemented.</text:span></text:p>
-     </office:annotation> – Well Block Average Pressure Calculation Parameters for All Wells<text:bookmark-end text:name="__RefHeading___Toc121923_2556401936"/></text:h>
+     </office:annotation> – <text:span text:style-name="T29">W</text:span>ell <text:span text:style-name="T26">Block Average Pressure Calculation Parameters for All Wells</text:span><text:bookmark-end text:name="__RefHeading___Toc121923_2556401936"/></text:h>
     <table:table table:name="Table705" table:style-name="Table705">
      <table:table-column table:style-name="Table705.A" table:number-columns-repeated="4"/>
      <table:table-column table:style-name="Table705.E"/>
@@ -4529,33 +4530,33 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      <table:table-column table:style-name="Table705.A" table:number-columns-repeated="2"/>
      <table:table-row table:style-name="Table705.1">
       <table:table-cell table:style-name="Table705.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#3.RUNSPEC SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">RUNSPEC</text:span></text:a></text:p>
+       <text:p text:style-name="P72"><text:a xlink:type="simple" xlink:href="#3.RUNSPEC SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">RUNSPEC</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table705.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#4.GRID SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">GRID</text:span></text:a></text:p>
+       <text:p text:style-name="P73"><text:a xlink:type="simple" xlink:href="#4.GRID SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">GRID</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table705.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#5.EDIT SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">EDIT</text:span></text:a></text:p>
+       <text:p text:style-name="P73"><text:a xlink:type="simple" xlink:href="#5.EDIT SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">EDIT</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table705.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#6.PROPS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">PROPS</text:span></text:a></text:p>
+       <text:p text:style-name="P73"><text:a xlink:type="simple" xlink:href="#6.PROPS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">PROPS</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table705.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#7.REGIONS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">REGIONS</text:span></text:a></text:p>
+       <text:p text:style-name="P73"><text:a xlink:type="simple" xlink:href="#7.REGIONS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">REGIONS</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table705.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#8.SOLUTION SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SOLUTION</text:span></text:a></text:p>
+       <text:p text:style-name="P73"><text:a xlink:type="simple" xlink:href="#8.SOLUTION SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SOLUTION</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table705.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#9.SUMMARY SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SUMMARY</text:span></text:a></text:p>
+       <text:p text:style-name="P73"><text:a xlink:type="simple" xlink:href="#9.SUMMARY SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SUMMARY</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table705.H1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#10.SCHEDULE SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SCHEDULE</text:span></text:a></text:p>
+       <text:p text:style-name="P73"><text:a xlink:type="simple" xlink:href="#10.SCHEDULE SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SCHEDULE</text:span></text:a></text:p>
       </table:table-cell>
      </table:table-row>
     </table:table>
-    <text:h text:style-name="P61" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc716799_3964674244"/>Description<text:bookmark-end text:name="__RefHeading___Toc716799_3964674244"/></text:h>
-    <text:p text:style-name="_40_TextBody">The WPAVE keyword defines the method and parameters for calculating a well’s block average pressures for all wells in the model. The resulting average pressure can be written out to the SUMMARY and RSM files in order to compare with field observed data via the WBP, WBP4, WBP5 and WBP9 vectors in the SUMMARY section.</text:p>
+    <text:h text:style-name="P50" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc716799_3964674244"/>Description<text:bookmark-end text:name="__RefHeading___Toc716799_3964674244"/></text:h>
+    <text:p text:style-name="P74">The <text:span text:style-name="T24">WPAVE</text:span> keyword defines <text:span text:style-name="T24">the method and parameters for calculating a well’s block average pressures for all wells in the model. The resulting average pressure can be written out to the </text:span><text:span text:style-name="T22">SUMMARY</text:span><text:span text:style-name="T24"> </text:span><text:span text:style-name="T32">and RSM </text:span><text:span text:style-name="T24">file</text:span><text:span text:style-name="T32">s</text:span><text:span text:style-name="T24"> in order to compare with field observed data</text:span><text:span text:style-name="T32"> via the WBP, </text:span><text:span text:style-name="T24">WBP4, WBP5 and WBP9 </text:span><text:span text:style-name="T32">vectors in the SUMMARY section</text:span><text:span text:style-name="T24">.</text:span></text:p>
     <table:table table:name="Table706" table:style-name="Table706">
      <table:table-column table:style-name="Table706.A"/>
      <table:table-column table:style-name="Table706.B"/>
@@ -4565,129 +4566,129 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      <table:table-header-rows>
       <table:table-row table:style-name="Table706.1">
        <table:table-cell table:style-name="Table706.A1" table:number-rows-spanned="2" office:value-type="string">
-        <text:p text:style-name="P49">No.</text:p>
+        <text:p text:style-name="P38">No.</text:p>
        </table:table-cell>
        <table:table-cell table:style-name="Table706.A1" table:number-rows-spanned="2" office:value-type="string">
-        <text:p text:style-name="P49">Name</text:p>
+        <text:p text:style-name="P38">Name</text:p>
        </table:table-cell>
        <table:table-cell table:style-name="Table706.A1" table:number-columns-spanned="3" office:value-type="string">
-        <text:p text:style-name="P49">Description</text:p>
+        <text:p text:style-name="P38">Description</text:p>
        </table:table-cell>
        <table:covered-table-cell/>
        <table:covered-table-cell/>
        <table:table-cell table:style-name="Table706.F1" table:number-rows-spanned="2" office:value-type="string">
-        <text:p text:style-name="P49">Default</text:p>
+        <text:p text:style-name="P38">Default</text:p>
        </table:table-cell>
       </table:table-row>
       <table:table-row table:style-name="Table706.1">
        <table:covered-table-cell table:style-name="Table706.A1"/>
        <table:covered-table-cell table:style-name="Table706.A1"/>
        <table:table-cell table:style-name="Table706.C2" office:value-type="string">
-        <text:p text:style-name="P49">Field</text:p>
+        <text:p text:style-name="P38">Field</text:p>
        </table:table-cell>
        <table:table-cell table:style-name="Table706.C2" office:value-type="string">
-        <text:p text:style-name="P49">Metric</text:p>
+        <text:p text:style-name="P38">Metric</text:p>
        </table:table-cell>
        <table:table-cell table:style-name="Table706.C2" office:value-type="string">
-        <text:p text:style-name="P49">Laboratory</text:p>
+        <text:p text:style-name="P38">Laboratory</text:p>
        </table:table-cell>
        <table:covered-table-cell table:style-name="Table706.F1"/>
       </table:table-row>
      </table:table-header-rows>
      <table:table-row table:style-name="Table706.3">
       <table:table-cell table:style-name="Table706.A3" office:value-type="string">
-       <text:p text:style-name="P86">1</text:p>
+       <text:p text:style-name="P35">1</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table706.C2" office:value-type="string">
-       <text:p text:style-name="P86">WPAVE1</text:p>
+       <text:p text:style-name="P36">W<text:span text:style-name="T27">PAVE1</text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table706.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P86">A real dimensionless value that defines the weighting factor between the inner block and the surrounding blocks used in the calculation of the connection factor weighted average pressure.</text:p>
-       <text:p text:style-name="P86">If WPAVE1 is greater than or equal to zero and less than or equal to one, then the average pressure for each well connection is calculated based on this weighting factor. A value of zero indicates only the surrounding blocks should be used in the calculation; and a value of one indicates only the inner blocks should be used.</text:p>
-       <text:p text:style-name="P86">If WPAVE1 is less than zero, then the average pressure for each well connection is weighted based on the pore volumes of the inner and surrounding blocks.</text:p>
+       <text:p text:style-name="P28">A <text:span text:style-name="T27">real dimensionless value that defines the weighting factor between the inner block and the surrounding blocks used </text:span><text:span text:style-name="T36">in the</text:span><text:span text:style-name="T27"> calculat</text:span><text:span text:style-name="T36">ion of</text:span><text:span text:style-name="T27"> the connection factor weighted average pressure.</text:span></text:p>
+       <text:p text:style-name="P27">If WPAVE1 is greater than or equal to zero and less than or equal to one, then the average pressure <text:span text:style-name="T36">for each well connection</text:span> <text:span text:style-name="T36">is</text:span> calculate<text:span text:style-name="T36">d</text:span> based on th<text:span text:style-name="T36">is</text:span> <text:span text:style-name="T36">weighting</text:span> factor. A value of zero indicates only the surrounding blocks should be used in the calculation; and a value of one indicates only the inner blocks <text:span text:style-name="T36">should be used</text:span>.</text:p>
+       <text:p text:style-name="P27">If WPAVE1 is <text:span text:style-name="T36">less than</text:span> zero, then <text:span text:style-name="T36">the </text:span>average<text:span text:style-name="T36"> </text:span>pressure <text:span text:style-name="T36">for each well connection</text:span> is <text:span text:style-name="T36">weighted</text:span> based on the pore volumes of the <text:span text:style-name="T36">inner and surrounding </text:span>blocks.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table706.F3" office:value-type="string">
-       <text:p text:style-name="P87">0.5</text:p>
+       <text:p text:style-name="P25">0.5</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table706.3">
       <table:table-cell table:style-name="Table706.A3" office:value-type="string">
-       <text:p text:style-name="P86">2</text:p>
+       <text:p text:style-name="P30">2</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table706.C2" office:value-type="string">
-       <text:p text:style-name="P86">WPAVE2</text:p>
+       <text:p text:style-name="P37">W<text:span text:style-name="T27">PAVE2</text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table706.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P86">A real dimensionless value greater than or equal to zero and less than or equal to one, that defines the weighting factor between the connection factor weighted average pressures and the pore volume weighted average pressures.</text:p>
-       <text:p text:style-name="P86">If WPAVE2 is equal to one, then the average pressures are calculated based only on the connection factor weighted average pressures. </text:p>
-       <text:p text:style-name="P86">If WPAVE2 is equal to zero, then average pressures are calculated based <text:s/>only on the pore volumes weighted average pressures.</text:p>
+       <text:p text:style-name="P29">A <text:span text:style-name="T27">real dimensionless value greater than or equal to zero and less than or equal to one, that defines the weighting factor between the connection </text:span><text:span text:style-name="T36">factor </text:span><text:span text:style-name="T27">weighted average pressures and the pore volume weighted average pressures.</text:span></text:p>
+       <text:p text:style-name="P84">If WPAVE<text:span text:style-name="T21">2</text:span> is equal to one, then the average pressures are calculate<text:span text:style-name="T36">d</text:span> based only <text:span text:style-name="T36">on</text:span> the connection factor <text:span text:style-name="T36">weighted</text:span><text:span text:style-name="T21"> </text:span><text:span text:style-name="T36">average </text:span><text:span text:style-name="T21">pressures</text:span>. </text:p>
+       <text:p text:style-name="P27">If WPAVE<text:span text:style-name="T21">2</text:span> is <text:span text:style-name="T21">equal to</text:span> zero, then average pressure<text:span text:style-name="T21">s</text:span> <text:span text:style-name="T21">are</text:span> calculate<text:span text:style-name="T36">d</text:span> based <text:s/><text:span text:style-name="T21">only </text:span><text:span text:style-name="T36">on </text:span>the pore volumes <text:span text:style-name="T36">weighted</text:span><text:span text:style-name="T21"> </text:span><text:span text:style-name="T36">average </text:span><text:span text:style-name="T21">pressures</text:span>.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table706.F3" office:value-type="string">
-       <text:p text:style-name="P86">1.0</text:p>
+       <text:p text:style-name="P26">1.0</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table706.3">
       <table:table-cell table:style-name="Table706.A3" office:value-type="string">
-       <text:p text:style-name="P86">3</text:p>
+       <text:p text:style-name="P31">3</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table706.C2" office:value-type="string">
-       <text:p text:style-name="P86">WPAVE3</text:p>
+       <text:p text:style-name="P33">WPAVE3</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table706.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P86">A defined character string that determines how the hydrostatic head calculation is performed in correcting the pressures to the BHP reference depth on the WELSPECS or WPAVEDEP keywords in the SCHEDULE section. WPAVE3 should be set to one of the following character strings:</text:p>
+       <text:p text:style-name="P32">A defined character string that determines how the hydrostatic head calculation is performed in correcting the pressures to the BHP reference depth on the WELSPECS or WPAVEDEP keywords in the <text:span text:style-name="T31">SCHEDULE</text:span> section. WPAVE3<text:span text:style-name="T23"> should be set to one of the following character strings:</text:span></text:p>
        <text:list text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P88">WELL: the hydrostatic head is calculated using the density of the fluid in the wellbore at the well connections.</text:p>
+         <text:p text:style-name="P81"><text:span text:style-name="T21">WELL</text:span>: <text:span text:style-name="T21">the hydrostatic head is calculated using the density of the fluid in the wellbore at the well connections.</text:span></text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P88">RES: he hydrostatic head is calculated using the density of the fluid in the reservoir with well connections and averaged over the connections.</text:p>
+         <text:p text:style-name="P82">RES: he hydrostatic head is calculated using the density of the fluid in the reservoir with well connections and averaged over the connections.</text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P88">NONE: no hydrostatic correction is applied to the pressures.</text:p>
+         <text:p text:style-name="P82">NONE: no hydrostatic correction is applied to the pressures.</text:p>
         </text:list-item>
        </text:list>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table706.F3" office:value-type="string">
-       <text:p text:style-name="P86">WELL</text:p>
+       <text:p text:style-name="P31">WELL</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table706.1">
       <table:table-cell table:style-name="Table706.A6" office:value-type="string">
-       <text:p text:style-name="P86">4</text:p>
+       <text:p text:style-name="P31">4</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table706.C2" office:value-type="string">
-       <text:p text:style-name="P86">WPAVE4</text:p>
+       <text:p text:style-name="P33">WPAVE4</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table706.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P86">A defined character string that determines which connections should be used in the calculations, WPAVE4 should be set to one of the following character strings:</text:p>
+       <text:p text:style-name="P32">A defined character string that determines which connections should be used in the calculations, WPAVE4<text:span text:style-name="T23"> should be set to one of the following character strings:</text:span></text:p>
        <text:list text:continue-numbering="true" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P88">OPEN: only open connections and associated grid blocks should be used in the calculations. This option may result in pressure discontinuities if connections are opened and closed during the run. </text:p>
+         <text:p text:style-name="P81"><text:span text:style-name="T21">OPEN</text:span>: <text:span text:style-name="T21">only open connections and associated grid blocks should be used in the calculations. This option may result in pressure discontinuities if connections are opened and closed during the run. </text:span></text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P88">ALL: all currently defined open and closed connections and associated grid blocks are used in the calculations. The pressure discontinuities issue mentioned above can be avoided with this option and defining all the well connections for a well at the beginning of the run. </text:p>
+         <text:p text:style-name="P82">ALL: all currently defined open and closed connections and associated grid blocks are used in the calculations. The pressure discontinuities issue mentioned above can be avoided with this option and defining all the well connections for a well at the beginning of the run. </text:p>
         </text:list-item>
        </text:list>
-       <text:p text:style-name="P86">Only the OPEN option is currently supported by the simulator.</text:p>
+       <text:p text:style-name="P85">Only <text:span text:style-name="T37">the </text:span><text:span text:style-name="T38">OPEN</text:span><text:span text:style-name="T37"> option</text:span> <text:span text:style-name="T37">is </text:span>currently <text:span text:style-name="T37">supported</text:span> <text:span text:style-name="T37">by the simulator</text:span>.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table706.F3" office:value-type="string">
-       <text:p text:style-name="P86">OPEN</text:p>
+       <text:p text:style-name="P31">OPEN</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table706.1">
       <table:table-cell table:style-name="Table706.A7" table:number-columns-spanned="6" office:value-type="string">
-       <text:p text:style-name="P87">Notes:</text:p>
+       <text:p text:style-name="P24">Notes:</text:p>
        <text:list text:style-name="L1">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P89">The keyword should be terminated by a “/”.</text:p>
+         <text:p text:style-name="P83"><text:span text:style-name="T19">The keyword</text:span><text:span text:style-name="T20"> should be terminated by a </text:span><text:span text:style-name="T19">“/”.</text:span></text:p>
         </text:list-item>
        </text:list>
       </table:table-cell>
@@ -4698,28 +4699,28 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
      </table:table-row>
     </table:table>
-    <text:p text:style-name="P81">Table <text:sequence text:ref-name="refTable0" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">12.3.309.1</text:sequence>: WPAVE Keyword Description</text:p>
-    <text:p text:style-name="P85"/>
-    <text:p text:style-name="P79">The keyword is not applicable and should not be used with radial and spider grid geometries.</text:p>
-    <text:p text:style-name="P79"><text:soft-page-break/>See also the WELSPECS keyword that defines a well and a well’s bottom-hole pressure reference depth, the WPAVEDEP keyword that also defines a well’s bottom-hole pressure reference depth, and the COMPDAT keyword to define a well’s connections. All the aforementioned keywords are described in the SCHEDULE section.</text:p>
-    <text:h text:style-name="P61" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc716801_3964674244"/>Examples<text:bookmark-end text:name="__RefHeading___Toc716801_3964674244"/></text:h>
-    <text:p text:style-name="P79">The following example defines the default well block average pressure calculation parameters</text:p>
-    <text:p text:style-name="P80">--</text:p>
-    <text:p text:style-name="P80">-- <text:s text:c="6"/>DEFINE WELL BLOCK AVERAGE PRESSURE CALCULATION PARAMETERS <text:s text:c="53"/></text:p>
-    <text:p text:style-name="P80">-- <text:s text:c="77"/></text:p>
-    <text:p text:style-name="P80">-- <text:s text:c="6"/>INNER <text:s text:c="2"/>PORV <text:s text:c="2"/>WELL <text:s/>OPEN <text:s text:c="28"/></text:p>
-    <text:p text:style-name="P80">-- <text:s text:c="6"/>OUTER <text:s text:c="2"/>CONN <text:s text:c="2"/>RES <text:s text:c="2"/>ALL</text:p>
-    <text:p text:style-name="P80">WPAVE <text:s text:c="75"/></text:p>
-    <text:p text:style-name="P80"><text:s text:c="9"/>0.5 <text:s text:c="4"/>1.0 <text:s text:c="3"/>WELL <text:s/>ALL <text:s text:c="45"/>/ <text:s text:c="77"/></text:p>
-    <text:p text:style-name="P79">And the next example shows the parameters used in the Norne model.</text:p>
-    <text:p text:style-name="P80">--</text:p>
-    <text:p text:style-name="P80">-- <text:s text:c="6"/>DEFINE WELL BLOCK AVERAGE PRESSURE CALCULATION PARAMETERS <text:s text:c="53"/></text:p>
-    <text:p text:style-name="P80">-- <text:s text:c="77"/></text:p>
-    <text:p text:style-name="P80">-- <text:s text:c="6"/>INNER <text:s text:c="2"/>PORV <text:s text:c="2"/>WELL <text:s/>OPEN <text:s text:c="28"/></text:p>
-    <text:p text:style-name="P80">-- <text:s text:c="6"/>OUTER <text:s text:c="2"/>CONN <text:s text:c="2"/>RES <text:s text:c="2"/>ALL</text:p>
-    <text:p text:style-name="P80">WPAVE <text:s text:c="75"/></text:p>
-    <text:p text:style-name="P80"><text:s text:c="9"/>1* <text:s text:c="5"/>0.0 <text:s text:c="3"/>WELL <text:s/>ALL <text:s text:c="45"/>/ <text:s text:c="77"/></text:p>
-    <text:p text:style-name="P79">Here only pore volume weighting is used instead of connection weighting.</text:p>
+    <text:p text:style-name="P46">Table <text:sequence text:ref-name="refTable0" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">12.3.309.1</text:sequence>: W<text:span text:style-name="T25">PAVE</text:span> Keyword Description</text:p>
+    <text:p text:style-name="P47"/>
+    <text:p text:style-name="P41"><text:span text:style-name="T32">The keyword is not applicable and should not be used </text:span><text:span text:style-name="T22">with</text:span><text:span text:style-name="T32"> radial and spider grid geometries.</text:span></text:p>
+    <text:p text:style-name="P41"><text:soft-page-break/>See also the WELSPECS keyword that defines a well <text:span text:style-name="T21">and a well’s bottom-hole pressure reference depth, the WPAVEDEP keyword that also defines a well’s bottom-hole pressure reference depth, and</text:span> the COMPDAT keyword to define a well’s connections. All the aforementioned keywords are described in the SCHEDULE section.</text:p>
+    <text:h text:style-name="P48" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc716801_3964674244"/>Example<text:span text:style-name="T30">s</text:span><text:bookmark-end text:name="__RefHeading___Toc716801_3964674244"/></text:h>
+    <text:p text:style-name="P40">The following example <text:span text:style-name="T28">defines the default well block average pressure calculation parameters</text:span></text:p>
+    <text:p text:style-name="P43">--</text:p>
+    <text:p text:style-name="P43">-- <text:s text:c="6"/>DEFINE WELL BLOCK AVERAGE PRESSURE CALCULATION PARAMETERS <text:s text:c="53"/></text:p>
+    <text:p text:style-name="P43">-- <text:s text:c="77"/></text:p>
+    <text:p text:style-name="P43">-- <text:s text:c="6"/>INNER <text:s text:c="2"/>PORV <text:s text:c="2"/>WELL <text:s/>OPEN <text:s text:c="28"/></text:p>
+    <text:p text:style-name="P43">-- <text:s text:c="6"/>OUTER <text:s text:c="2"/>CONN <text:s text:c="2"/>RES <text:s text:c="2"/>ALL</text:p>
+    <text:p text:style-name="P43">WPAVE <text:s text:c="75"/></text:p>
+    <text:p text:style-name="P45"><text:span text:style-name="T28"><text:s text:c="9"/>0.5 <text:s text:c="4"/>1.0 <text:s text:c="3"/>WELL <text:s/>ALL <text:s text:c="45"/></text:span>/ <text:s text:c="77"/></text:p>
+    <text:p text:style-name="P42">And the next example shows the parameters used in the Norne model.</text:p>
+    <text:p text:style-name="P43">--</text:p>
+    <text:p text:style-name="P43">-- <text:s text:c="6"/>DEFINE WELL BLOCK AVERAGE PRESSURE CALCULATION PARAMETERS <text:s text:c="53"/></text:p>
+    <text:p text:style-name="P43">-- <text:s text:c="77"/></text:p>
+    <text:p text:style-name="P43">-- <text:s text:c="6"/>INNER <text:s text:c="2"/>PORV <text:s text:c="2"/>WELL <text:s/>OPEN <text:s text:c="28"/></text:p>
+    <text:p text:style-name="P43">-- <text:s text:c="6"/>OUTER <text:s text:c="2"/>CONN <text:s text:c="2"/>RES <text:s text:c="2"/>ALL</text:p>
+    <text:p text:style-name="P43">WPAVE <text:s text:c="75"/></text:p>
+    <text:p text:style-name="P45"><text:span text:style-name="T28"><text:s text:c="9"/>1* <text:s text:c="5"/>0.0 <text:s text:c="3"/>WELL <text:s/>ALL <text:s text:c="45"/></text:span>/ <text:s text:c="77"/></text:p>
+    <text:p text:style-name="P44">Here only pore volume weighting is used <text:span text:style-name="T28">instead</text:span> of connection weighting.</text:p>
    </text:section>
   </office:text>
  </office:body>


### PR DESCRIPTION
Added partial support for WPAVE and WWPAVE defining the method and parameters for calculating a well’s block average pressures for either all wells or specific wells (OPM/opm-simulators#4695, OPM/opm-simulators#4694 and OPM/opm-simulators#4693). Calculation of block averages pressures is currently only supported for OPEN completions (not for ALL completions) as specified in WPAVE item 4 and WWPAVE item 5.