### PR TITLE
Update WWPAVE.fodt for 2023-10

### DIFF
--- a/parts/chapters/subsections/12.3/WWPAVE.fodt
+++ b/parts/chapters/subsections/12.3/WWPAVE.fodt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:officeooo="http://openoffice.org/2009/office" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
- <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT5H34M7S</meta:editing-duration><meta:editing-cycles>26</meta:editing-cycles><meta:generator>LibreOffice/7.6.2.1$Windows_X86_64 LibreOffice_project/56f7684011345957bbf33a7ee678afaf4d2ba333</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
+ <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT5H33M45S</meta:editing-duration><meta:editing-cycles>25</meta:editing-cycles><meta:generator>LibreOffice/7.6.2.1$Windows_X86_64 LibreOffice_project/56f7684011345957bbf33a7ee678afaf4d2ba333</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
 1) eq 
 2) F3
 
@@ -17,24 +17,24 @@ To insert a new keyword section (except for the header
 To insert standard text:
 1) t0, t1, t2
 2) F3
-Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:initial-creator>David Baxendale</meta:initial-creator><dc:date>2023-12-12T15:06:11.301000000</dc:date><meta:document-statistic meta:table-count="9" meta:image-count="0" meta:object-count="0" meta:page-count="4" meta:paragraph-count="147" meta:word-count="980" meta:character-count="6533" meta:non-whitespace-character-count="4747"/><meta:user-defined meta:name="ClientContact">ClientContact</meta:user-defined><meta:user-defined meta:name="ClientEmail">ClientEmail</meta:user-defined><meta:user-defined meta:name="ClientName">Equinor ASA</meta:user-defined><meta:user-defined meta:name="ClientOffice">ClientOfficeAddres</meta:user-defined><meta:user-defined meta:name="ClientRegistered" meta:value-type="string">ClientRegisteredAddress</meta:user-defined><meta:user-defined meta:name="ClientTelNo" meta:value-type="string">ClientTelNo</meta:user-defined><meta:user-defined meta:name="DocumentDate" meta:value-type="string">June 8, 2023</meta:user-defined><meta:user-defined meta:name="DocumentNumber" meta:value-type="string">2023-04-RPT</meta:user-defined><meta:user-defined meta:name="DocumentRevision" meta:value-type="string">Rev-0</meta:user-defined><meta:user-defined meta:name="ProgramVersion" meta:value-type="string">2023-04</meta:user-defined></office:meta>
+Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:initial-creator>David Baxendale</meta:initial-creator><dc:date>2023-12-12T11:13:22.614000000</dc:date><meta:document-statistic meta:table-count="9" meta:image-count="0" meta:object-count="0" meta:page-count="4" meta:paragraph-count="147" meta:word-count="980" meta:character-count="6529" meta:non-whitespace-character-count="4743"/><meta:user-defined meta:name="ClientContact">ClientContact</meta:user-defined><meta:user-defined meta:name="ClientEmail">ClientEmail</meta:user-defined><meta:user-defined meta:name="ClientName">Equinor ASA</meta:user-defined><meta:user-defined meta:name="ClientOffice">ClientOfficeAddres</meta:user-defined><meta:user-defined meta:name="ClientRegistered" meta:value-type="string">ClientRegisteredAddress</meta:user-defined><meta:user-defined meta:name="ClientTelNo" meta:value-type="string">ClientTelNo</meta:user-defined><meta:user-defined meta:name="DocumentDate" meta:value-type="string">June 8, 2023</meta:user-defined><meta:user-defined meta:name="DocumentNumber" meta:value-type="string">2023-04-RPT</meta:user-defined><meta:user-defined meta:name="DocumentRevision" meta:value-type="string">Rev-0</meta:user-defined><meta:user-defined meta:name="ProgramVersion" meta:value-type="string">2023-04</meta:user-defined></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
-   <config:config-item config:name="ViewAreaTop" config:type="long">79904</config:config-item>
+   <config:config-item config:name="ViewAreaTop" config:type="long">29104</config:config-item>
    <config:config-item config:name="ViewAreaLeft" config:type="long">0</config:config-item>
    <config:config-item config:name="ViewAreaWidth" config:type="long">21500</config:config-item>
-   <config:config-item config:name="ViewAreaHeight" config:type="long">24384</config:config-item>
+   <config:config-item config:name="ViewAreaHeight" config:type="long">24370</config:config-item>
    <config:config-item config:name="ShowRedlineChanges" config:type="boolean">true</config:config-item>
    <config:config-item config:name="InBrowseMode" config:type="boolean">false</config:config-item>
    <config:config-item-map-indexed config:name="Views">
     <config:config-item-map-entry>
      <config:config-item config:name="ViewId" config:type="string">view2</config:config-item>
-     <config:config-item config:name="ViewLeft" config:type="long">10185</config:config-item>
-     <config:config-item config:name="ViewTop" config:type="long">95536</config:config-item>
+     <config:config-item config:name="ViewLeft" config:type="long">4279</config:config-item>
+     <config:config-item config:name="ViewTop" config:type="long">77401</config:config-item>
      <config:config-item config:name="VisibleLeft" config:type="long">0</config:config-item>
-     <config:config-item config:name="VisibleTop" config:type="long">79904</config:config-item>
+     <config:config-item config:name="VisibleTop" config:type="long">29104</config:config-item>
      <config:config-item config:name="VisibleRight" config:type="long">21498</config:config-item>
-     <config:config-item config:name="VisibleBottom" config:type="long">104286</config:config-item>
+     <config:config-item config:name="VisibleBottom" config:type="long">53472</config:config-item>
      <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutColumns" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutBookMode" config:type="boolean">false</config:config-item>
@@ -116,7 +116,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <config:config-item config:name="LoadReadonly" config:type="boolean">false</config:config-item>
    <config:config-item config:name="ClipAsCharacterAnchoredWriterFlyFrames" config:type="boolean">false</config:config-item>
    <config:config-item config:name="UseOldPrinterMetrics" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="Rsid" config:type="int">1989929</config:config-item>
+   <config:config-item config:name="Rsid" config:type="int">1893195</config:config-item>
    <config:config-item config:name="RsidRoot" config:type="int">130112</config:config-item>
    <config:config-item config:name="ProtectForm" config:type="boolean">false</config:config-item>
    <config:config-item config:name="MsWordCompTrailingBlanks" config:type="boolean">false</config:config-item>
@@ -508,7 +508,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
   </draw:fill-image>
   <style:default-style style:family="graphic">
    <style:graphic-properties svg:stroke-color="#000000" draw:fill-color="#99ccff" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.3cm" draw:shadow-offset-y="0.3cm" draw:start-line-spacing-horizontal="0.283cm" draw:start-line-spacing-vertical="0.283cm" draw:end-line-spacing-horizontal="0.283cm" draw:end-line-spacing-vertical="0.283cm" style:writing-mode="lr-tb" style:flow-with-text="false"/>
-   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0cm" style:font-independent-line-spacing="false">
+   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0cm" style:writing-mode="lr-tb" style:font-independent-line-spacing="false">
     <style:tab-stops/>
    </style:paragraph-properties>
    <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Times New Roman1" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="DejaVu Sans" style:font-size-asian="12pt" style:language-asian="zxx" style:country-asian="none" style:font-name-complex="Lucidasans1" style:font-size-complex="12pt" style:language-complex="zxx" style:country-complex="none"/>
@@ -997,15 +997,15 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:graphic-properties>
   </style:style>
   <style:style style:name="Frame" style:family="graphic">
-   <style:graphic-properties svg:width="17.189cm" fo:min-width="60%" svg:height="14.848cm" fo:min-height="56%" text:anchor-type="paragraph" svg:x="2.702cm" svg:y="0cm" fo:margin-left="0.508cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:run-through="foreground" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph-content" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" fo:background-color="transparent" draw:fill="none" draw:fill-color="#99ccff" fo:padding="0.152cm" fo:border="0.06pt solid #000000" style:shadow="#000000 0.178cm 0.178cm" draw:shadow-opacity="100%" loext:rel-width-rel="paragraph" loext:rel-height-rel="paragraph">
+   <style:graphic-properties svg:width="17.189cm" fo:min-width="60%" svg:height="14.848cm" fo:min-height="56%" text:anchor-type="paragraph" svg:x="2.702cm" svg:y="0cm" fo:margin-left="0.508cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:run-through="foreground" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph-content" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" fo:background-color="transparent" draw:fill="none" fo:padding="0.152cm" fo:border="0.06pt solid #000000" style:shadow="#000000 0.178cm 0.178cm" draw:shadow-opacity="100%" loext:rel-width-rel="paragraph" loext:rel-height-rel="paragraph">
     <style:columns fo:column-count="1" fo:column-gap="0cm"/>
    </style:graphic-properties>
   </style:style>
   <style:style style:name="Formula" style:family="graphic">
-   <style:graphic-properties text:anchor-type="as-char" svg:y="0cm" fo:margin-left="0.051cm" fo:margin-right="0.051cm" style:wrap="parallel" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="middle" style:vertical-rel="text" fo:background-color="transparent" draw:fill="none" draw:fill-color="#99ccff" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true"/>
+   <style:graphic-properties text:anchor-type="as-char" svg:y="0cm" fo:margin-left="0.051cm" fo:margin-right="0.051cm" style:wrap="parallel" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="middle" style:vertical-rel="text" fo:background-color="transparent" draw:fill="none" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true"/>
   </style:style>
   <style:style style:name="OLE" style:family="graphic">
-   <style:graphic-properties text:anchor-type="paragraph" svg:x="0cm" svg:y="0cm" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" fo:background-color="transparent" draw:fill="none" draw:fill-color="#99ccff"/>
+   <style:graphic-properties text:anchor-type="paragraph" svg:x="0cm" svg:y="0cm" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" fo:background-color="transparent" draw:fill="none"/>
   </style:style>
   <text:outline-style style:name="Outline">
    <text:outline-level-style text:level="1" loext:num-list-format="CHAPTER %1%:" style:num-prefix="CHAPTER " style:num-suffix=":" style:num-format="1" text:start-value="12">
@@ -2759,60 +2759,50 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
   <style:style style:name="P37" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="001ce34b"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06db8512" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
   <style:style style:name="P38" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06db8512" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
   <style:style style:name="P39" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06db8512" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
   <style:style style:name="P40" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06db8512" officeooo:paragraph-rsid="13d5751d"/>
-  </style:style>
-  <style:style style:name="P41" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06db8512" officeooo:paragraph-rsid="001ce34b"/>
-  </style:style>
-  <style:style style:name="P42" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062cbd9a" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P43" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P41" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062cbd9a" officeooo:paragraph-rsid="062cbd9a"/>
   </style:style>
-  <style:style style:name="P44" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P42" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062cbd9a" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P45" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P43" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06dd3088" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P46" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P44" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06dd3088" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P45" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06dd3088" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P46" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -2822,53 +2812,53 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06dd3088" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="13d5751d" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Table_20_Heading">
+  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Table_20_Heading">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="Table">
+  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Table">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="Standard">
+  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="Standard">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="Heading_20_4">
+  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="Heading_20_4">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="063c3886" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="00c4ec6d" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="0e8c8ea6" officeooo:paragraph-rsid="0e8c8ea6"/>
   </style:style>
-  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="13d8a0f1" officeooo:paragraph-rsid="13d8a0f1"/>
   </style:style>
-  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="_40_Example">
+  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="_40_Example">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="13d8a0f1"/>
   </style:style>
-  <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Heading_20_3">
+  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Heading_20_3">
    <style:paragraph-properties fo:break-before="page"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="17f9214c"/>
   </style:style>
-  <style:style style:name="P61" style:family="paragraph" style:parent-style-name="Heading_20_4">
+  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Heading_20_4">
    <style:text-properties fo:language="en" fo:country="US"/>
   </style:style>
-  <style:style style:name="P62" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="05c7f16b" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P63" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P61" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
     <style:tab-stops>
@@ -2878,39 +2868,34 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06305dda" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P64" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="07876263" officeooo:paragraph-rsid="001ce34b"/>
-  </style:style>
-  <style:style style:name="P65" style:family="paragraph" style:parent-style-name="_40_Table_20_Contents">
+  <style:style style:name="P62" style:family="paragraph" style:parent-style-name="_40_Table_20_Contents">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties officeooo:paragraph-rsid="14d36d55"/>
   </style:style>
-  <style:style style:name="P66" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P63" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
   </style:style>
-  <style:style style:name="P67" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P64" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" officeooo:rsid="0117c15b" officeooo:paragraph-rsid="0117c15b" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
-  <style:style style:name="P68" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P65" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
-  <style:style style:name="P69" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P66" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" officeooo:paragraph-rsid="13ac3201" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
-  <style:style style:name="P70" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P67" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
-  <style:style style:name="P71" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P68" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" fo:language="en" fo:country="US" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
-  <style:style style:name="P72" style:family="paragraph" style:parent-style-name="Footer">
+  <style:style style:name="P69" style:family="paragraph" style:parent-style-name="Footer">
    <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
     <style:tab-stops>
@@ -2920,7 +2905,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="07061c8d" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P73" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
+  <style:style style:name="P70" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
    <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
     <style:tab-stops>
@@ -2930,75 +2915,85 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P74" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P71" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties officeooo:rsid="003d1478" officeooo:paragraph-rsid="0e8c8ea6"/>
   </style:style>
-  <style:style style:name="P75" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P72" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="0e8c8ea6"/>
   </style:style>
-  <style:style style:name="P76" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P73" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <loext:graphic-properties draw:fill="none"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" style:writing-mode="lr-tb"/>
    <style:text-properties officeooo:rsid="13d5751d" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P77" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P74" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties officeooo:paragraph-rsid="13d8a0f1"/>
   </style:style>
-  <style:style style:name="P78" style:family="paragraph" style:parent-style-name="_40_Example">
+  <style:style style:name="P75" style:family="paragraph" style:parent-style-name="_40_Example">
    <style:text-properties officeooo:paragraph-rsid="13d8a0f1"/>
   </style:style>
-  <style:style style:name="P79" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P76" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties officeooo:rsid="06a03e71" officeooo:paragraph-rsid="0e8c8ea6"/>
   </style:style>
-  <style:style style:name="P80" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P77" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:paragraph-properties fo:break-before="page"/>
   </style:style>
-  <style:style style:name="P81" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+  <style:style style:name="P78" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
    <style:paragraph-properties style:page-number="auto"/>
   </style:style>
-  <style:style style:name="P82" style:family="paragraph" style:parent-style-name="_40_Example">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P83" style:family="paragraph" style:parent-style-name="Table">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P84" style:family="paragraph" style:parent-style-name="Table_20_Heading">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P85" style:family="paragraph" style:parent-style-name="_40_TextBody">
-   <style:text-properties fo:language="en" fo:country="US"/>
-  </style:style>
-  <style:style style:name="P86" style:family="paragraph" style:parent-style-name="Heading_20_3">
+  <style:style style:name="P79" style:family="paragraph" style:parent-style-name="Heading_20_3">
    <style:paragraph-properties fo:break-before="page"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="17f9214c"/>
+  </style:style>
+  <style:style style:name="P80" style:family="paragraph" style:parent-style-name="Heading_20_4">
    <style:text-properties fo:language="en" fo:country="US"/>
   </style:style>
-  <style:style style:name="P87" style:family="paragraph" style:parent-style-name="Heading_20_4">
-   <style:text-properties fo:language="en" fo:country="US"/>
+  <style:style style:name="P81" style:family="paragraph" style:parent-style-name="Heading_20_4">
+   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P88" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="First_20_Page">
+  <style:style style:name="P82" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="First_20_Page">
    <style:paragraph-properties style:page-number="auto"/>
   </style:style>
-  <style:style style:name="P89" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties fo:language="en" fo:country="US"/>
+  <style:style style:name="P83" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06305dda" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P90" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US"/>
+  <style:style style:name="P84" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="0.961cm"/>
+     <style:tab-stop style:position="1.27cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06dd3088" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P91" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:text-properties fo:language="en" fo:country="US"/>
+  <style:style style:name="P85" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="L1">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="05c7f16b" officeooo:paragraph-rsid="13d5751d"/>
   </style:style>
-  <style:style style:name="P92" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
-   <style:paragraph-properties style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US"/>
+  <style:style style:name="P86" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="06db8512" officeooo:paragraph-rsid="001ce34b"/>
   </style:style>
-  <style:style style:name="P93" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="L1">
-   <style:text-properties fo:language="en" fo:country="US"/>
+  <style:style style:name="P87" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="062e77b5" officeooo:paragraph-rsid="001ce34b"/>
   </style:style>
-  <style:style style:name="P94" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties style:writing-mode="lr-tb"/>
+  <style:style style:name="P88" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:margin-top="0.076cm" fo:margin-bottom="0.076cm" style:contextual-spacing="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:rsid="07876263" officeooo:paragraph-rsid="001ce34b"/>
   </style:style>
   <style:style style:name="T1" style:family="text">
    <style:text-properties fo:font-size="20pt" style:font-size-asian="20pt" style:font-size-complex="20pt"/>
@@ -4530,9 +4525,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:user-field-decl office:value-type="float" office:value="1" text:name="MD"/>
     <text:user-field-decl office:value-type="string" office:string-value="" text:name="SEQ CHAPTER \h   1"/>
    </text:user-field-decls>
-   <text:p text:style-name="P88"/>
+   <text:p text:style-name="P82"/>
    <text:section text:style-name="Sect1" text:name="WWPAVE">
-    <text:h text:style-name="P86" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc1464916_4263943340"/>WWPAVE – Well Block Average Pressure Calculation Parameters for Individual Wells<text:bookmark-end text:name="__RefHeading___Toc1464916_4263943340"/></text:h>
+    <text:h text:style-name="P58" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc1464916_4263943340"/>WWPAVE – Well Block Average Pressure Calculation Parameters <text:span text:style-name="T32">for Individual Wells</text:span><text:bookmark-end text:name="__RefHeading___Toc1464916_4263943340"/></text:h>
     <table:table table:name="Table1770" table:style-name="Table1770">
      <table:table-column table:style-name="Table1770.A" table:number-columns-repeated="4"/>
      <table:table-column table:style-name="Table1770.E"/>
@@ -4540,34 +4535,34 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      <table:table-column table:style-name="Table1770.A" table:number-columns-repeated="2"/>
      <table:table-row table:style-name="Table1770.1">
       <table:table-cell table:style-name="Table1770.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#3.RUNSPEC SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">RUNSPEC</text:span></text:a></text:p>
+       <text:p text:style-name="P71"><text:a xlink:type="simple" xlink:href="#3.RUNSPEC SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">RUNSPEC</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1770.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#4.GRID SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">GRID</text:span></text:a></text:p>
+       <text:p text:style-name="P72"><text:a xlink:type="simple" xlink:href="#4.GRID SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">GRID</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1770.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#5.EDIT SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">EDIT</text:span></text:a></text:p>
+       <text:p text:style-name="P72"><text:a xlink:type="simple" xlink:href="#5.EDIT SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">EDIT</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1770.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#6.PROPS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">PROPS</text:span></text:a></text:p>
+       <text:p text:style-name="P72"><text:a xlink:type="simple" xlink:href="#6.PROPS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">PROPS</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1770.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#7.REGIONS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">REGIONS</text:span></text:a></text:p>
+       <text:p text:style-name="P72"><text:a xlink:type="simple" xlink:href="#7.REGIONS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">REGIONS</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1770.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#8.SOLUTION SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SOLUTION</text:span></text:a></text:p>
+       <text:p text:style-name="P72"><text:a xlink:type="simple" xlink:href="#8.SOLUTION SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SOLUTION</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1770.A1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#9.SUMMARY SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SUMMARY</text:span></text:a></text:p>
+       <text:p text:style-name="P72"><text:a xlink:type="simple" xlink:href="#9.SUMMARY SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SUMMARY</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1770.H1" office:value-type="string">
-       <text:p text:style-name="Table_20_Contents"><text:a xlink:type="simple" xlink:href="#10.SCHEDULE SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SCHEDULE</text:span></text:a></text:p>
+       <text:p text:style-name="P72"><text:a xlink:type="simple" xlink:href="#10.SCHEDULE SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SCHEDULE</text:span></text:a></text:p>
       </table:table-cell>
      </table:table-row>
     </table:table>
-    <text:h text:style-name="P61" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc716913_3964674244"/>Description<text:bookmark-end text:name="__RefHeading___Toc716913_3964674244"/></text:h>
-    <text:p text:style-name="_40_TextBody">The WWPAVE keyword defines the method and parameters for calculating a well’s block average pressures for individual wells that can be written to the SUMMARY and RSM files via the WBP, WBP4, WBP5 and WBP9 vectors in the SUMMARY section. <text:s/>The resulting average pressure can be written out to the summary file in order to compared with field observed data. The keyword is similar to the WPAVE keyword in the SCHEDULE section that has similar functionality, but is applied to all wells in the model. </text:p>
-    <text:p text:style-name="_40_TextBody">Note that WWPAVE will overwrite any parameters on the WPAVE keyword for a given well, and that WWPAVE can also be overwritten by any subsequent WPAVE keyword. </text:p>
+    <text:h text:style-name="P59" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc716913_3964674244"/>Description<text:bookmark-end text:name="__RefHeading___Toc716913_3964674244"/></text:h>
+    <text:p text:style-name="P74">The <text:span text:style-name="T28">WWPAVE</text:span> keyword defines <text:span text:style-name="T28">the method and parameters for calculating a well’s block average pressures for individual wells </text:span><text:span text:style-name="T36">that can be written to the SUMMARY and RSM files via the WBP, </text:span><text:span text:style-name="T28">WBP4, WBP5 and WBP9 </text:span><text:span text:style-name="T36">vectors in the SUMMARY section</text:span><text:span text:style-name="T28">. <text:s/>The resulting average pressure can be written out to the summary file in order to compared with field observed data. The keyword is similar to the WPAVE keyword in the SCHEDULE section that has similar functionality, but is applied to all wells in the model. </text:span></text:p>
+    <text:p text:style-name="P76">Note that WWPAVE will overwrite any parameters on the WPAVE keyword for a given well, and that WWPAVE can also be overwritten by any subsequent WPAVE keyword. </text:p>
     <table:table table:name="Table1949" table:style-name="Table1949">
      <table:table-column table:style-name="Table1949.A"/>
      <table:table-column table:style-name="Table1949.B"/>
@@ -4577,147 +4572,147 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      <table:table-header-rows>
       <table:table-row table:style-name="Table1949.1">
        <table:table-cell table:style-name="Table1949.A1" table:number-rows-spanned="2" office:value-type="string">
-        <text:p text:style-name="P84">No.</text:p>
+        <text:p text:style-name="P48">No.</text:p>
        </table:table-cell>
        <table:table-cell table:style-name="Table1949.A1" table:number-rows-spanned="2" office:value-type="string">
-        <text:p text:style-name="P84">Name</text:p>
+        <text:p text:style-name="P48">Name</text:p>
        </table:table-cell>
        <table:table-cell table:style-name="Table1949.A1" table:number-columns-spanned="3" office:value-type="string">
-        <text:p text:style-name="P84">Description</text:p>
+        <text:p text:style-name="P48">Description</text:p>
        </table:table-cell>
        <table:covered-table-cell/>
        <table:covered-table-cell/>
        <table:table-cell table:style-name="Table1949.F1" table:number-rows-spanned="2" office:value-type="string">
-        <text:p text:style-name="P84">Default</text:p>
+        <text:p text:style-name="P48">Default</text:p>
        </table:table-cell>
       </table:table-row>
       <table:table-row table:style-name="Table1949.1">
        <table:covered-table-cell table:style-name="Table1949.A1"/>
        <table:covered-table-cell table:style-name="Table1949.A1"/>
        <table:table-cell table:style-name="Table1949.C2" office:value-type="string">
-        <text:p text:style-name="P84">Field</text:p>
+        <text:p text:style-name="P48">Field</text:p>
        </table:table-cell>
        <table:table-cell table:style-name="Table1949.C2" office:value-type="string">
-        <text:p text:style-name="P84">Metric</text:p>
+        <text:p text:style-name="P48">Metric</text:p>
        </table:table-cell>
        <table:table-cell table:style-name="Table1949.C2" office:value-type="string">
-        <text:p text:style-name="P84">Laboratory</text:p>
+        <text:p text:style-name="P48">Laboratory</text:p>
        </table:table-cell>
        <table:covered-table-cell table:style-name="Table1949.F1"/>
       </table:table-row>
      </table:table-header-rows>
      <table:table-row table:style-name="Table1949.3">
       <table:table-cell table:style-name="Table1949.A3" office:value-type="string">
-       <text:p text:style-name="P90">1</text:p>
+       <text:p text:style-name="P47">1</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1949.C2" office:value-type="string">
-       <text:p text:style-name="P90">WELNAME</text:p>
+       <text:p text:style-name="P41">WELNAME</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1949.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P90">A character string of up to eight characters in length that defines the well name for which the well average pressure calculation parameters are being defined.</text:p>
-       <text:p text:style-name="P90">Note that the well name (WELNAME) must have been declared previously using the WELSPECS keyword in the SCHEDULE section, otherwise an error may occur.</text:p>
+       <text:p text:style-name="P36">A character string of up to eight characters in length that defines the <text:span text:style-name="T33">well</text:span> name for which the <text:span text:style-name="T21">well </text:span><text:span text:style-name="T24">a</text:span><text:span text:style-name="T22">verage pressure calculation parameters are</text:span><text:span text:style-name="T33"> being defined.</text:span></text:p>
+       <text:p text:style-name="P40">Note that the well name (WELNAME) must have been declared previously using the WELSPECS keyword in the SCHEDULE section, otherwise an error may occur.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table1949.F3" office:value-type="string">
-       <text:p text:style-name="P91">None</text:p>
+       <text:p text:style-name="P35">None</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table1949.3">
       <table:table-cell table:style-name="Table1949.A4" table:formula="ooow:&lt;A3&gt;+1" office:value-type="float" office:value="2">
-       <text:p text:style-name="P94">2</text:p>
+       <text:p text:style-name="P73">2</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1949.C2" office:value-type="string">
-       <text:p text:style-name="P90">WPAVE1</text:p>
+       <text:p text:style-name="P42">W<text:span text:style-name="T30">PAVE1</text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1949.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P90">A real dimensionless value that defines the weighting factor between the inner block and the surrounding blocks used in the calculation of the connection factor weighted average pressure.</text:p>
-       <text:p text:style-name="P90">If WPAVE1 is greater than or equal to zero and less than or equal to one, then the average pressure for each well connection is calculated based on this weighting factor. A value of zero indicates only the surrounding blocks should be used in the calculation; and a value of one indicates only the inner blocks should be used.</text:p>
-       <text:p text:style-name="P90">If WPAVE1 is less than zero, then the average pressure for each well connection is weighted based on the pore volumes of the inner and surrounding blocks.</text:p>
+       <text:p text:style-name="P87">A <text:span text:style-name="T30">real dimensionless value that defines the weighting factor between the inner block and the surrounding blocks used </text:span><text:span text:style-name="T37">in the</text:span><text:span text:style-name="T30"> calculat</text:span><text:span text:style-name="T37">ion of</text:span><text:span text:style-name="T30"> the connection factor weighted average pressure.</text:span></text:p>
+       <text:p text:style-name="P86">If WPAVE1 is greater than or equal to zero and less than or equal to one, then the average pressure <text:span text:style-name="T37">for each well connection</text:span> <text:span text:style-name="T37">is</text:span> calculate<text:span text:style-name="T37">d</text:span> based on th<text:span text:style-name="T37">is</text:span> <text:span text:style-name="T37">weighting</text:span> factor. A value of zero indicates only the surrounding blocks should be used in the calculation; and a value of one indicates only the inner blocks <text:span text:style-name="T37">should be used</text:span>.</text:p>
+       <text:p text:style-name="P86">If WPAVE1 is <text:span text:style-name="T37">less than</text:span> zero, then <text:span text:style-name="T37">the </text:span>average<text:span text:style-name="T37"> </text:span>pressure <text:span text:style-name="T37">for each well connection</text:span> is <text:span text:style-name="T37">weighted</text:span> based on the pore volumes of the <text:span text:style-name="T37">inner and surrounding </text:span>blocks.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table1949.F3" office:value-type="string">
-       <text:p text:style-name="P91">0.5</text:p>
+       <text:p text:style-name="P37">0.5</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table1949.3">
       <table:table-cell table:style-name="Table1949.A5" table:formula="ooow:&lt;A4&gt;+1" office:value-type="float" office:value="3">
-       <text:p text:style-name="P94">3</text:p>
+       <text:p text:style-name="P73">3</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1949.C2" office:value-type="string">
-       <text:p text:style-name="P90">WPAVE2</text:p>
+       <text:p text:style-name="P42">W<text:span text:style-name="T30">PAVE2</text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1949.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P90">A real dimensionless value greater than or equal to zero and less than or equal to one, that defines the weighting factor between the connection weighted average pressures and the pore volume weighted average pressures.</text:p>
-       <text:p text:style-name="P90">If WPAVE2 is equal to one, then the average pressures are calculate based only using the connection factor calculated pressures. </text:p>
-       <text:p text:style-name="P90">If WPAVE2 is equal to zero, then average pressures are calculate based on only using the pore volumes calculated pressures.</text:p>
+       <text:p text:style-name="P36">A <text:span text:style-name="T30">real dimensionless value greater than or equal to zero and less than or equal to one, that defines the weighting factor between the connection weighted average pressures and the pore volume weighted average pressures.</text:span></text:p>
+       <text:p text:style-name="P39">If WPAVE<text:span text:style-name="T25">2</text:span> is equal to one, then the average pressures are calculate based only using the connection factor <text:span text:style-name="T25">calculated pressures</text:span>. </text:p>
+       <text:p text:style-name="P39">If WPAVE<text:span text:style-name="T25">2</text:span> is <text:span text:style-name="T25">equal to</text:span> zero, then average pressure<text:span text:style-name="T25">s</text:span> <text:span text:style-name="T25">are</text:span> calculate based on <text:span text:style-name="T25">only using </text:span>the pore volumes <text:span text:style-name="T25">calculated pressures</text:span>.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table1949.F3" office:value-type="string">
-       <text:p text:style-name="P90">1.0</text:p>
+       <text:p text:style-name="P38">1.0</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table1949.3">
       <table:table-cell table:style-name="Table1949.A6" table:formula="ooow:&lt;A5&gt;+1" office:value-type="float" office:value="4">
-       <text:p text:style-name="P94">4</text:p>
+       <text:p text:style-name="P73">4</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1949.C2" office:value-type="string">
-       <text:p text:style-name="P90">WPAVE3</text:p>
+       <text:p text:style-name="P45">WPAVE3</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1949.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P90">A defined character string that determines how the hydrostatic head calculation is performed in correcting the pressures to the BHP reference depth on the WELSPECS or WPAVEDEP keywords in the SCHEDULE section. WPAVE3 should be set to one of the following character strings:</text:p>
+       <text:p text:style-name="P44">A defined character string that determines how the hydrostatic head calculation is performed in correcting the pressures to the BHP reference depth on the WELSPECS or WPAVEDEP keywords in the <text:span text:style-name="T23">SCHEDULE</text:span> section. WPAVE3<text:span text:style-name="T27"> should be set to one of the following character strings:</text:span></text:p>
        <text:list text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P92">WELL: the hydrostatic head is calculated using the density of the fluid in the wellbore at the well connections.</text:p>
+         <text:p text:style-name="P83"><text:span text:style-name="T25">WELL</text:span>: <text:span text:style-name="T25">the hydrostatic head is calculated using the density of the fluid in the wellbore at the well connections.</text:span></text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P92">RES: he hydrostatic head is calculated using the density of the fluid in the reservoir with well connections and averaged over the connections.</text:p>
+         <text:p text:style-name="P84">RES: he hydrostatic head is calculated using the density of the fluid in the reservoir with well connections and averaged over the connections.</text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P92">NONE: no hydrostatic correction is applied to the pressures.</text:p>
+         <text:p text:style-name="P84">NONE: no hydrostatic correction is applied to the pressures.</text:p>
         </text:list-item>
        </text:list>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table1949.F3" office:value-type="string">
-       <text:p text:style-name="P90">WELL</text:p>
+       <text:p text:style-name="P43">WELL</text:p>
       </table:table-cell>
      </table:table-row>
      <text:soft-page-break/>
      <table:table-row table:style-name="Table1949.1">
       <table:table-cell table:style-name="Table1949.A7" table:formula="ooow:&lt;A6&gt;+1" office:value-type="float" office:value="5">
-       <text:p text:style-name="P94">5</text:p>
+       <text:p text:style-name="P73">5</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1949.C2" office:value-type="string">
-       <text:p text:style-name="P90">WPAVE4</text:p>
+       <text:p text:style-name="P45">WPAVE4</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1949.C2" table:number-columns-spanned="3" office:value-type="string">
-       <text:p text:style-name="P90">A defined character string that determines which connections should be used in the calculations, WPAVE4 should be set to one of the following character strings:</text:p>
+       <text:p text:style-name="P44">A defined character string that determines which connections should be used in the calculations, WPAVE4<text:span text:style-name="T27"> should be set to one of the following character strings:</text:span></text:p>
        <text:list text:continue-numbering="true" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P92">OPEN: only open connections and associated grid blocks should be used in the calculations. This option may result in pressure discontinuities if connections are opened and closed during the run. </text:p>
+         <text:p text:style-name="P83"><text:span text:style-name="T25">OPEN</text:span>: <text:span text:style-name="T25">only open connections and associated grid blocks should be used in the calculations. This option may result in pressure discontinuities if connections are opened and closed during the run. </text:span></text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P92">ALL: all currently defined open and closed connections and associated grid blocks are used in the calculations. The pressure discontinuities issue mentioned above can be avoided with this option and defining all the well connections for a well at the beginning of the run. </text:p>
+         <text:p text:style-name="P84">ALL: all currently defined open and closed connections and associated grid blocks are used in the calculations. The pressure discontinuities issue mentioned above can be avoided with this option and defining all the well connections for a well at the beginning of the run. </text:p>
         </text:list-item>
        </text:list>
-       <text:p text:style-name="P90">Only the OPEN option is currently supported by the simulator.</text:p>
+       <text:p text:style-name="P88">Only <text:span text:style-name="T38">the </text:span><text:span text:style-name="T39">OPEN</text:span><text:span text:style-name="T38"> option</text:span> <text:span text:style-name="T38">is </text:span>currently <text:span text:style-name="T38">supported</text:span> <text:span text:style-name="T38">by the simulator</text:span>.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table1949.F3" office:value-type="string">
-       <text:p text:style-name="P90">OPEN</text:p>
+       <text:p text:style-name="P43">OPEN</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table1949.1">
       <table:table-cell table:style-name="Table1949.A8" table:number-columns-spanned="6" office:value-type="string">
-       <text:p text:style-name="P91">Notes:</text:p>
+       <text:p text:style-name="P34">Notes:</text:p>
        <text:list text:style-name="L1">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P93">The keyword should be terminated by a “/”.</text:p>
+         <text:p text:style-name="P85"><text:span text:style-name="T19">The keyword</text:span><text:span text:style-name="T20"> should be terminated by a </text:span><text:span text:style-name="T19">“/”.</text:span></text:p>
         </text:list-item>
        </text:list>
       </table:table-cell>
@@ -4728,35 +4723,35 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
      </table:table-row>
     </table:table>
-    <text:p text:style-name="P83">Table <text:sequence text:ref-name="refTable0" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">12.3.356.1</text:sequence>: WWPAVE Keyword Description</text:p>
-    <text:p text:style-name="P89"/>
-    <text:p text:style-name="P85">The keyword is not applicable and should not be used with radial and spider grid geometries.</text:p>
-    <text:p text:style-name="P85">See also the WELSPECS keyword that defines a well and a well’s bottom-hole pressure reference depth, the WPAVEDEP keyword that also defines a well’s bottom-hole pressure reference depth, and the COMPDAT keyword to define a well’s connections. All the aforementioned keywords are described in the SCHEDULE section.</text:p>
-    <text:h text:style-name="P61" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc716801_39646742441"/>Examples<text:bookmark-end text:name="__RefHeading___Toc716801_39646742441"/></text:h>
-    <text:p text:style-name="P85">The following example defines the default well block average pressure calculation parameters for three oil wells: OP01, OP02 and OP03.</text:p>
+    <text:p text:style-name="P50">Table <text:sequence text:ref-name="refTable0" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">12.3.356.1</text:sequence>: W<text:span text:style-name="T35">W</text:span><text:span text:style-name="T29">PAVE</text:span> Keyword Description</text:p>
+    <text:p text:style-name="P51"/>
+    <text:p text:style-name="P56">The keyword is not applicable and should not be used <text:span text:style-name="T26">with</text:span> radial and spider grid geometries.</text:p>
+    <text:p text:style-name="P54">See also the WELSPECS keyword that defines a well <text:span text:style-name="T25">and a well’s bottom-hole pressure reference depth, the WPAVEDEP keyword that also defines a well’s bottom-hole pressure reference depth, and</text:span> the COMPDAT keyword to define a well’s connections. All the aforementioned keywords are described in the SCHEDULE section.</text:p>
+    <text:h text:style-name="P52" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc716801_39646742441"/>Example<text:span text:style-name="T34">s</text:span><text:bookmark-end text:name="__RefHeading___Toc716801_39646742441"/></text:h>
+    <text:p text:style-name="P53">The following example <text:span text:style-name="T31">defines the default well block average pressure calculation parameters for three oil wells: OP01, OP02 and OP03.</text:span></text:p>
     <text:p text:style-name="_40_Example">--</text:p>
     <text:p text:style-name="_40_Example">-- <text:s text:c="6"/>DEFINE WELL BLOCK AVERAGE PRESSURE CALCULATION PARAMETERS <text:s text:c="53"/></text:p>
     <text:p text:style-name="_40_Example">-- <text:s text:c="77"/></text:p>
     <text:p text:style-name="_40_Example">-- WELL <text:s/>INNER <text:s text:c="2"/>PORV <text:s text:c="2"/>WELL <text:s/>OPEN <text:s text:c="28"/></text:p>
     <text:p text:style-name="_40_Example">-- NAME <text:s/>OUTER <text:s text:c="2"/>CONN <text:s text:c="2"/>RES <text:s text:c="2"/>ALL</text:p>
-    <text:p text:style-name="_40_Example">WWPAVE <text:s text:c="75"/></text:p>
+    <text:p text:style-name="_40_Example">W<text:span text:style-name="T40">W</text:span>PAVE <text:s text:c="75"/></text:p>
     <text:p text:style-name="_40_Example">OP01 <text:s text:c="4"/>0.5 <text:s text:c="4"/>1.0 <text:s text:c="3"/>WELL <text:s/>ALL <text:s text:c="46"/>/</text:p>
     <text:p text:style-name="_40_Example">OP02 <text:s text:c="4"/>0.5 <text:s text:c="4"/>1.0 <text:s text:c="3"/>WELL <text:s/>ALL <text:s text:c="46"/>/</text:p>
     <text:p text:style-name="_40_Example">OP03 <text:s text:c="4"/>0.5 <text:s text:c="4"/>1.0 <text:s text:c="3"/>1* <text:s text:c="3"/>1* <text:s text:c="47"/>/</text:p>
     <text:p text:style-name="_40_Example"/>
     <text:p text:style-name="_40_TextBody"/>
-    <text:p text:style-name="P80">And the next example shows the parameters used in the Norne model.</text:p>
-    <text:p text:style-name="_40_Example">--</text:p>
-    <text:p text:style-name="_40_Example">-- <text:s text:c="6"/>DEFINE WELL BLOCK AVERAGE PRESSURE CALCULATION PARAMETERS <text:s text:c="53"/></text:p>
-    <text:p text:style-name="_40_Example">-- <text:s text:c="77"/></text:p>
-    <text:p text:style-name="_40_Example">-- WELL <text:s/>INNER <text:s text:c="2"/>PORV <text:s text:c="2"/>WELL <text:s/>OPEN <text:s text:c="28"/></text:p>
-    <text:p text:style-name="_40_Example">-- NAME <text:s/>OUTER <text:s text:c="2"/>CONN <text:s text:c="2"/>RES <text:s text:c="2"/>ALL</text:p>
-    <text:p text:style-name="_40_Example">WPAVE <text:s text:c="75"/></text:p>
-    <text:p text:style-name="_40_Example">OP01 <text:s text:c="4"/>1* <text:s text:c="5"/>0.0 <text:s text:c="3"/>WELL <text:s/>ALL <text:s text:c="46"/>/</text:p>
-    <text:p text:style-name="_40_Example">OP02 <text:s text:c="4"/>1* <text:s text:c="5"/>0.0 <text:s text:c="3"/>WELL <text:s/>ALL <text:s text:c="46"/>/</text:p>
-    <text:p text:style-name="_40_Example">OP03 <text:s text:c="4"/>1* <text:s text:c="5"/>0.0 <text:s text:c="3"/>WELL <text:s/>ALL <text:s text:c="46"/>/</text:p>
-    <text:p text:style-name="P82"><text:s text:c="77"/></text:p>
-    <text:p text:style-name="P85">Here only pore volume weighting is used instead of connection weighting.</text:p>
+    <text:p text:style-name="P77">And the next example shows the parameters used in the Norne model.</text:p>
+    <text:p text:style-name="P75">--</text:p>
+    <text:p text:style-name="P75">-- <text:s text:c="6"/>DEFINE WELL BLOCK AVERAGE PRESSURE CALCULATION PARAMETERS <text:s text:c="53"/></text:p>
+    <text:p text:style-name="P75">-- <text:s text:c="77"/></text:p>
+    <text:p text:style-name="P75">-- WELL <text:s/>INNER <text:s text:c="2"/>PORV <text:s text:c="2"/>WELL <text:s/>OPEN <text:s text:c="28"/></text:p>
+    <text:p text:style-name="P75">-- NAME <text:s/>OUTER <text:s text:c="2"/>CONN <text:s text:c="2"/>RES <text:s text:c="2"/>ALL</text:p>
+    <text:p text:style-name="P75">WPAVE <text:s text:c="75"/></text:p>
+    <text:p text:style-name="P75">OP01 <text:s text:c="4"/>1* <text:s text:c="5"/>0.0 <text:s text:c="3"/>WELL <text:s/>ALL <text:s text:c="46"/>/</text:p>
+    <text:p text:style-name="P75">OP02 <text:s text:c="4"/>1* <text:s text:c="5"/>0.0 <text:s text:c="3"/>WELL <text:s/>ALL <text:s text:c="46"/>/</text:p>
+    <text:p text:style-name="P75">OP03 <text:s text:c="4"/>1* <text:s text:c="5"/>0.0 <text:s text:c="3"/>WELL <text:s/>ALL <text:s text:c="46"/>/</text:p>
+    <text:p text:style-name="P57"><text:s text:c="77"/></text:p>
+    <text:p text:style-name="P49">Here only pore volume weighting is used <text:span text:style-name="T31">instead</text:span> of connection weighting.</text:p>
    </text:section>
   </office:text>
  </office:body>


### PR DESCRIPTION
Added partial support for WPAVE and WWPAVE defining the method and parameters for calculating a well’s block average pressures for either all wells or specific wells (OPM/opm-simulators#4695, OPM/opm-simulators#4694 and OPM/opm-simulators#4693). Calculation of block averages pressures is currently only supported for OPEN completions (not for ALL completions) as specified in WPAVE item 4 and WWPAVE item 5.