### PR TITLE
Fix master styles

### DIFF
--- a/parts/meta/sections/master-styles.xml
+++ b/parts/meta/sections/master-styles.xml
@@ -112,86 +112,86 @@
      <table:table-column table:style-name="Table109.Z"></table:table-column>
      <table:table-row table:style-name="TableLine94708556406544">
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P443"><text:span text:style-name="Internet_20_link"><text:bookmark-ref text:reference-format="text" text:ref-name="A">A</text:bookmark-ref></text:span></text:p>
+       <text:p text:style-name="P443"><text:span text:style-name="Internet_20_link">A</text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1201"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="B">B</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1201"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">B</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="C">C</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">C</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="D">D</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">D</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="E">E</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">E</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="F">F</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">F</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="G">G</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">G</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="H">H</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">H</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1206"><text:bookmark-ref text:reference-format="text" text:ref-name="I">I</text:bookmark-ref></text:p>
+       <text:p text:style-name="P1206">I</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="J">J</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">J</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="E">E</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">K</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="L">L</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">L</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1203"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T506"><text:bookmark-ref text:reference-format="text" text:ref-name="M">M</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1203"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T506">M</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="N">N</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">N</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="O">O</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">O</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="P">P</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">P</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="Q">Q</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">Q</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="R">R</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">R</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="S">S</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">S</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="T">T</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">T</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="U">U</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">U</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P2575"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="V">V</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P2575"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">V</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P2793"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="W">W</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P2793"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">W</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="X">X</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">X</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.A1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="Y">Y</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">Y</text:span></text:span></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table109.Z1" office:value-type="string">
-       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="Z">Z</text:bookmark-ref></text:span></text:span></text:p>
+       <text:p text:style-name="P1202"><text:span text:style-name="Internet_20_link"><text:span text:style-name="T1">Z</text:span></text:span></text:p>
       </table:table-cell>
      </table:table-row>
     </table:table>
-    <text:p text:style-name="P3"><text:span text:style-name="T1">Date: </text:span><text:span text:style-name="T1"><text:user-defined style:data-style-name="N0" text:name="DocumentDate">June 8, 2023</text:user-defined></text:span><text:span text:style-name="T1"><text:tab></text:tab></text:span><text:a xlink:type="simple" xlink:href="#Table of Contents" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="Table of Contents">Table of Contents</text:bookmark-ref></text:span></text:a><text:span text:style-name="T1"><text:tab></text:tab>Page </text:span><text:span text:style-name="T1"><text:page-number text:select-page="current">2575</text:page-number></text:span><text:span text:style-name="T1"><text:s></text:s>of </text:span><text:span text:style-name="T1"><text:expression text:formula="ooow:Page-8" office:value-type="float" office:value="2718" style:data-style-name="N0">2718</text:expression></text:span></text:p>
+    <text:p text:style-name="P3"><text:span text:style-name="T1">Date: </text:span><text:span text:style-name="T1"><text:user-defined style:data-style-name="N0" text:name="DocumentDate">June 8, 2023</text:user-defined></text:span><text:span text:style-name="T1"><text:tab></text:tab></text:span><text:a xlink:type="simple" xlink:href="#Table of Contents" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1">Table of Contents</text:span></text:a><text:span text:style-name="T1"><text:tab></text:tab>Page </text:span><text:span text:style-name="T1"><text:page-number text:select-page="current">2575</text:page-number></text:span><text:span text:style-name="T1"><text:s></text:s>of </text:span><text:span text:style-name="T1"><text:expression text:formula="ooow:Page-8" office:value-type="float" office:value="2718" style:data-style-name="N0">2718</text:expression></text:span></text:p>
    </style:footer>
   </style:master-page>
   <style:master-page style:name="_40_ChapterFirstPage" style:display-name="@ChapterFirstPage" style:page-layout-name="pm12" draw:style-name="dp4" style:next-style-name="Standard">
@@ -231,7 +231,7 @@
     <text:p text:style-name="P1"></text:p>
    </style:header>
    <style:footer>
-    <text:p text:style-name="P4"><text:span text:style-name="T1">Date: </text:span><text:span text:style-name="T1"><text:user-defined style:data-style-name="N0" text:name="DocumentDate">June 8, 2023</text:user-defined></text:span><text:span text:style-name="T1"><text:tab></text:tab></text:span><text:a xlink:type="simple" xlink:href="#Table of Contents" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="Table of Contents">Table of Contents</text:bookmark-ref></text:span></text:a><text:span text:style-name="T1"><text:tab></text:tab>Page </text:span><text:span text:style-name="T1"><text:page-number text:select-page="current">1829</text:page-number></text:span><text:span text:style-name="T1"><text:s></text:s>of </text:span><text:span text:style-name="T1"><text:expression text:formula="ooow:Page-8" office:value-type="float" office:value="2718" style:data-style-name="N0">2718</text:expression></text:span></text:p>
+    <text:p text:style-name="P4"><text:span text:style-name="T1">Date: </text:span><text:span text:style-name="T1"><text:user-defined style:data-style-name="N0" text:name="DocumentDate">June 8, 2023</text:user-defined></text:span><text:span text:style-name="T1"><text:tab></text:tab></text:span><text:a xlink:type="simple" xlink:href="#Table of Contents" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1">Table of Contents</text:span></text:a><text:span text:style-name="T1"><text:tab></text:tab>Page </text:span><text:span text:style-name="T1"><text:page-number text:select-page="current">1829</text:page-number></text:span><text:span text:style-name="T1"><text:s></text:s>of </text:span><text:span text:style-name="T1"><text:expression text:formula="ooow:Page-8" office:value-type="float" office:value="2718" style:data-style-name="N0">2718</text:expression></text:span></text:p>
    </style:footer>
   </style:master-page>
   <style:master-page style:name="_40_ChapterPageStyle" style:display-name="@ChapterPageStyle" style:page-layout-name="pm13" draw:style-name="dp3">
@@ -271,7 +271,7 @@
     <text:p text:style-name="P1"></text:p>
    </style:header>
    <style:footer>
-    <text:p text:style-name="P4"><text:span text:style-name="T1">Date: </text:span><text:span text:style-name="T1"><text:user-defined style:data-style-name="N0" text:name="DocumentDate">June 8, 2023</text:user-defined></text:span><text:span text:style-name="T1"><text:tab></text:tab></text:span><text:a xlink:type="simple" xlink:href="#Table of Contents" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="Table of Contents">Table of Contents</text:bookmark-ref></text:span></text:a><text:span text:style-name="T1"><text:tab></text:tab>Page </text:span><text:span text:style-name="T1"><text:page-number text:select-page="current">223</text:page-number></text:span><text:span text:style-name="T1"><text:s></text:s>of </text:span><text:span text:style-name="T1"><text:expression text:formula="ooow:Page-8" office:value-type="float" office:value="2718" style:data-style-name="N0">2718</text:expression></text:span></text:p>
+    <text:p text:style-name="P4"><text:span text:style-name="T1">Date: </text:span><text:span text:style-name="T1"><text:user-defined style:data-style-name="N0" text:name="DocumentDate">June 8, 2023</text:user-defined></text:span><text:span text:style-name="T1"><text:tab></text:tab></text:span><text:a xlink:type="simple" xlink:href="#Table of Contents" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1">Table of Contents</text:span></text:a><text:span text:style-name="T1"><text:tab></text:tab>Page </text:span><text:span text:style-name="T1"><text:page-number text:select-page="current">223</text:page-number></text:span><text:span text:style-name="T1"><text:s></text:s>of </text:span><text:span text:style-name="T1"><text:expression text:formula="ooow:Page-8" office:value-type="float" office:value="2718" style:data-style-name="N0">2718</text:expression></text:span></text:p>
    </style:footer>
   </style:master-page>
   <style:master-page style:name="_40_AppendixPageStyle" style:display-name="@AppendixPageStyle" style:page-layout-name="pm13" draw:style-name="dp3">
@@ -311,7 +311,7 @@
     <text:p text:style-name="P1"></text:p>
    </style:header>
    <style:footer>
-    <text:p text:style-name="P4"><text:span text:style-name="T1">Date: </text:span><text:span text:style-name="T1"><text:user-defined style:data-style-name="N0" text:name="DocumentDate">June 8, 2023</text:user-defined></text:span><text:span text:style-name="T1"><text:tab></text:tab></text:span><text:a xlink:type="simple" xlink:href="#Table of Contents" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="Table of Contents">Table of Contents</text:bookmark-ref></text:span></text:a><text:span text:style-name="T1"><text:tab></text:tab>Page </text:span><text:span text:style-name="T1"><text:page-number text:select-page="current">3060</text:page-number></text:span><text:span text:style-name="T1"><text:s></text:s>of </text:span><text:span text:style-name="T1"><text:expression text:formula="ooow:Page-7" office:value-type="float" office:value="2719" style:data-style-name="N0">2719</text:expression></text:span></text:p>
+    <text:p text:style-name="P4"><text:span text:style-name="T1">Date: </text:span><text:span text:style-name="T1"><text:user-defined style:data-style-name="N0" text:name="DocumentDate">June 8, 2023</text:user-defined></text:span><text:span text:style-name="T1"><text:tab></text:tab></text:span><text:a xlink:type="simple" xlink:href="#Table of Contents" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1">Table of Contents</text:span></text:a><text:span text:style-name="T1"><text:tab></text:tab>Page </text:span><text:span text:style-name="T1"><text:page-number text:select-page="current">3060</text:page-number></text:span><text:span text:style-name="T1"><text:s></text:s>of </text:span><text:span text:style-name="T1"><text:expression text:formula="ooow:Page-7" office:value-type="float" office:value="2719" style:data-style-name="N0">2719</text:expression></text:span></text:p>
    </style:footer>
   </style:master-page>
   <style:master-page style:name="_40_AppendixFirstPage" style:display-name="@AppendixFirstPage" style:page-layout-name="pm14" draw:style-name="dp4" style:next-style-name="_40_AppendixPageStyle">
@@ -351,7 +351,7 @@
     <text:p text:style-name="P1"></text:p>
    </style:header>
    <style:footer>
-    <text:p text:style-name="P4"><text:span text:style-name="T1">Date: </text:span><text:span text:style-name="T1"><text:user-defined style:data-style-name="N0" text:name="DocumentDate">June 8, 2023</text:user-defined></text:span><text:span text:style-name="T1"><text:tab></text:tab></text:span><text:a xlink:type="simple" xlink:href="#Table of Contents" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="Table of Contents">Table of Contents</text:bookmark-ref></text:span></text:a><text:span text:style-name="T1"><text:tab></text:tab>Page </text:span><text:span text:style-name="T1"><text:page-number text:select-page="current">2903</text:page-number></text:span><text:span text:style-name="T1"><text:s></text:s>of </text:span><text:span text:style-name="T1"><text:expression text:formula="ooow:Page-8" office:value-type="float" office:value="2718" style:data-style-name="N0">2718</text:expression></text:span></text:p>
+    <text:p text:style-name="P4"><text:span text:style-name="T1">Date: </text:span><text:span text:style-name="T1"><text:user-defined style:data-style-name="N0" text:name="DocumentDate">June 8, 2023</text:user-defined></text:span><text:span text:style-name="T1"><text:tab></text:tab></text:span><text:a xlink:type="simple" xlink:href="#Table of Contents" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1">Table of Contents</text:span></text:a><text:span text:style-name="T1"><text:tab></text:tab>Page </text:span><text:span text:style-name="T1"><text:page-number text:select-page="current">2903</text:page-number></text:span><text:span text:style-name="T1"><text:s></text:s>of </text:span><text:span text:style-name="T1"><text:expression text:formula="ooow:Page-8" office:value-type="float" office:value="2718" style:data-style-name="N0">2718</text:expression></text:span></text:p>
    </style:footer>
   </style:master-page>
   <style:master-page style:name="Envelope" style:page-layout-name="pm15"></style:master-page>

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -29,6 +29,7 @@ fodt-extract-style-info = "fodt.extract_style_info:extract_style_info"
 fodt-extract-appendix = "fodt.extract_appendix:extract_appendix"
 fodt-remove-lines = "fodt.remove_lines:remove_lines"
 fodt-set-keyword-status = "fodt.add_keyword_status:set_keyword_status"
+fodt-remove-bookmarks-from-master-styles = "fodt.remove_bookmarks:remove_bookmarks_from_master_styles"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/src/fodt/remove_bookmarks.py
+++ b/scripts/src/fodt/remove_bookmarks.py
@@ -1,0 +1,116 @@
+# Remove bookmark refs from the master style section in all subdocuments.
+
+import io
+import logging
+import xml.sax
+import xml.sax.handler
+import xml.sax.xmlreader
+import xml.sax.saxutils
+from pathlib import Path
+
+import click
+
+from fodt.constants import ClickOptions
+from fodt.xml_helpers import XMLHelper
+
+class ElementHandler(xml.sax.handler.ContentHandler):
+    # Find the master-styles section and remove all bookmark refs from it.
+    # The master-styles section has tag name "office:master-styles".
+    # A book mark ref has tag name "text:bookmark-ref".
+
+    def __init__(self) -> None:
+        self.content = io.StringIO()
+        self.in_master_styles = False
+        self.nesting = 0
+
+    def characters(self, content: str):
+        self.content.write(xml.sax.saxutils.escape(content))
+
+    def endElement(self, name: str):
+        if self.in_master_styles:
+            if name == "office:master-styles":
+                self.in_master_styles = False
+            elif name == "text:bookmark-ref":
+                # remove this tag
+                return
+        self.content.write(XMLHelper.endtag(name))
+
+    def get_content(self) -> str:
+        return self.content.getvalue()
+
+    def startDocument(self):
+        self.content.write(XMLHelper.header)
+
+    def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
+        # logging.info(f"startElement: {name}")
+        if (not self.in_master_styles) and name == "office:master-styles":
+            self.in_master_styles = True
+        if self.in_master_styles and name == "text:bookmark-ref":
+            # remove this tag
+            return
+        self.content.write(XMLHelper.starttag(name, attrs))
+
+class RemoveBookmarksFromMasterStyles():
+    def __init__(self, maindir: str, filename: str|None, directory: str|None) -> None:
+        self.maindir = Path(maindir)
+        self.filename = filename
+        self.directory = directory
+
+    def remove_bookmarks(self) -> None:
+        if self.directory is not None:
+            filenames = list(Path(self.maindir / self.directory).glob("*.fodt"))
+        else:
+            filenames = [Path(self.maindir / self.filename)]
+        logging.info(f"Found {len(filenames)} files.")
+        logging.info(f"Filenames: {filenames}")
+        for filename in filenames:
+            self.remove_bookmarks_from_file(filename)
+
+    def remove_bookmarks_from_file(self, filename: str) -> None:
+        logging.info(f"Processing {filename}.")
+        parser = xml.sax.make_parser()
+        handler = ElementHandler()
+        parser.setContentHandler(handler)
+        parser.parse(filename)
+        with open(filename, "w", encoding='utf8') as f:
+            f.write(handler.get_content())
+
+
+# USAGE:
+#
+#   fodt-remove-bookmarks-from-master-styles \
+#        --filename=<fodt_input_file>
+#        --directory=<subdocument directory>
+#
+# DESCRIPTION:
+#
+#   Remove bookmark refs from the master style section in all subdocuments in the
+#   specified directory or in the specified file. Filenames and directory names
+#   are relative to the main directory.
+#
+@click.command()
+@ClickOptions.maindir(required=False)
+@click.option(
+    "--filename",
+    help="Subdocument filename.",
+    required=False,
+)
+@click.option(
+    "--directory",
+    help="Subdocument directory.",
+    required=False,
+)
+def remove_bookmarks_from_master_styles(
+    maindir: str, filename: str|None, directory: str|None
+) -> None:
+    """Remove bookmark refs from the master style section in all subdocuments."""
+    logging.basicConfig(level=logging.INFO)
+    if (filename is not None) and (directory is not None):
+        raise ValueError("Specify either filename or directory.")
+    if filename is None and directory is None:
+        raise ValueError("Specify either filename or directory.")
+    logging.info(f"Removing bookmark refs from master styles in {maindir}.")
+    RemoveBookmarksFromMasterStyles(maindir, filename, directory).remove_bookmarks()
+
+if __name__ == "__main__":
+    remove_bookmarks_from_master_styles()


### PR DESCRIPTION
_[Builds on PR #26, which should be merged first]_

Created script to remove bookmarks. See https://github.com/OPM/opm-reference-manual/pull/25#issuecomment-1857747361 for background.
    
Created a script to remove bookmarks from master-styles section in sub documents. These bookmarks should be removed since they refer to references in the main document. They will therefore be displayed as broken references when sub documents are opened in libreofffice. 
    
Also removed bookmarks from the file master-styles.xml file since this file is used by the add keyword command.

Next, I plan to use this script on all the sub documents and submit the changes to the subdocuments as separate PRs. Since there are over 1400 subdocuments, I plan to submit changes in a sequence of PRs to make the review easier. One for each chapter.


