### PR TITLE
Update WAGHYSTR.fodt for 2023-10

### DIFF
--- a/parts/chapters/subsections/8.3/WAGHYSTR.fodt
+++ b/parts/chapters/subsections/8.3/WAGHYSTR.fodt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:officeooo="http://openoffice.org/2009/office" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
- <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT5H52M4S</meta:editing-duration><meta:editing-cycles>25</meta:editing-cycles><meta:generator>LibreOffice/7.6.2.1$Windows_X86_64 LibreOffice_project/56f7684011345957bbf33a7ee678afaf4d2ba333</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
+ <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT6H7M19S</meta:editing-duration><meta:editing-cycles>26</meta:editing-cycles><meta:generator>LibreOffice/7.6.2.1$Windows_X86_64 LibreOffice_project/56f7684011345957bbf33a7ee678afaf4d2ba333</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
 1) eq 
 2) F3
 
@@ -17,24 +17,24 @@ To insert a new keyword section (except for the header
 To insert standard text:
 1) t0, t1, t2
 2) F3
-Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:initial-creator>David Baxendale</meta:initial-creator><dc:date>2023-12-19T16:34:57.620000000</dc:date><meta:document-statistic meta:table-count="9" meta:image-count="0" meta:object-count="5" meta:page-count="4" meta:paragraph-count="174" meta:word-count="1215" meta:character-count="7932" meta:non-whitespace-character-count="6361"/><meta:user-defined meta:name="ClientContact">ClientContact</meta:user-defined><meta:user-defined meta:name="ClientEmail">ClientEmail</meta:user-defined><meta:user-defined meta:name="ClientName">Equinor ASA</meta:user-defined><meta:user-defined meta:name="ClientOffice">ClientOfficeAddres</meta:user-defined><meta:user-defined meta:name="ClientRegistered" meta:value-type="string">ClientRegisteredAddress</meta:user-defined><meta:user-defined meta:name="ClientTelNo" meta:value-type="string">ClientTelNo</meta:user-defined><meta:user-defined meta:name="DocumentDate" meta:value-type="string">June 8, 2023</meta:user-defined><meta:user-defined meta:name="DocumentNumber" meta:value-type="string">2023-04-RPT</meta:user-defined><meta:user-defined meta:name="DocumentRevision" meta:value-type="string">Rev-0</meta:user-defined><meta:user-defined meta:name="ProgramVersion" meta:value-type="string">2023-04</meta:user-defined></office:meta>
+Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:initial-creator>David Baxendale</meta:initial-creator><dc:date>2024-01-03T14:02:26.878000000</dc:date><meta:document-statistic meta:table-count="9" meta:image-count="0" meta:object-count="5" meta:page-count="4" meta:paragraph-count="175" meta:word-count="1231" meta:character-count="8023" meta:non-whitespace-character-count="6437"/><meta:user-defined meta:name="ClientContact">ClientContact</meta:user-defined><meta:user-defined meta:name="ClientEmail">ClientEmail</meta:user-defined><meta:user-defined meta:name="ClientName">Equinor ASA</meta:user-defined><meta:user-defined meta:name="ClientOffice">ClientOfficeAddres</meta:user-defined><meta:user-defined meta:name="ClientRegistered" meta:value-type="string">ClientRegisteredAddress</meta:user-defined><meta:user-defined meta:name="ClientTelNo" meta:value-type="string">ClientTelNo</meta:user-defined><meta:user-defined meta:name="DocumentDate" meta:value-type="string">June 8, 2023</meta:user-defined><meta:user-defined meta:name="DocumentNumber" meta:value-type="string">2023-04-RPT</meta:user-defined><meta:user-defined meta:name="DocumentRevision" meta:value-type="string">Rev-0</meta:user-defined><meta:user-defined meta:name="ProgramVersion" meta:value-type="string">2023-04</meta:user-defined></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
-   <config:config-item config:name="ViewAreaTop" config:type="long">22516</config:config-item>
+   <config:config-item config:name="ViewAreaTop" config:type="long">77034</config:config-item>
    <config:config-item config:name="ViewAreaLeft" config:type="long">0</config:config-item>
    <config:config-item config:name="ViewAreaWidth" config:type="long">24571</config:config-item>
-   <config:config-item config:name="ViewAreaHeight" config:type="long">27578</config:config-item>
+   <config:config-item config:name="ViewAreaHeight" config:type="long">28169</config:config-item>
    <config:config-item config:name="ShowRedlineChanges" config:type="boolean">true</config:config-item>
    <config:config-item config:name="InBrowseMode" config:type="boolean">false</config:config-item>
    <config:config-item-map-indexed config:name="Views">
     <config:config-item-map-entry>
      <config:config-item config:name="ViewId" config:type="string">view2</config:config-item>
-     <config:config-item config:name="ViewLeft" config:type="long">16168</config:config-item>
-     <config:config-item config:name="ViewTop" config:type="long">83825</config:config-item>
+     <config:config-item config:name="ViewLeft" config:type="long">11060</config:config-item>
+     <config:config-item config:name="ViewTop" config:type="long">100115</config:config-item>
      <config:config-item config:name="VisibleLeft" config:type="long">0</config:config-item>
-     <config:config-item config:name="VisibleTop" config:type="long">22516</config:config-item>
+     <config:config-item config:name="VisibleTop" config:type="long">77034</config:config-item>
      <config:config-item config:name="VisibleRight" config:type="long">24569</config:config-item>
-     <config:config-item config:name="VisibleBottom" config:type="long">50093</config:config-item>
+     <config:config-item config:name="VisibleBottom" config:type="long">105202</config:config-item>
      <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutColumns" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutBookMode" config:type="boolean">false</config:config-item>
@@ -116,7 +116,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    <config:config-item config:name="LoadReadonly" config:type="boolean">false</config:config-item>
    <config:config-item config:name="ClipAsCharacterAnchoredWriterFlyFrames" config:type="boolean">false</config:config-item>
    <config:config-item config:name="UseOldPrinterMetrics" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="Rsid" config:type="int">1895287</config:config-item>
+   <config:config-item config:name="Rsid" config:type="int">1950124</config:config-item>
    <config:config-item config:name="RsidRoot" config:type="int">130112</config:config-item>
    <config:config-item config:name="ProtectForm" config:type="boolean">false</config:config-item>
    <config:config-item config:name="MsWordCompTrailingBlanks" config:type="boolean">false</config:config-item>
@@ -508,7 +508,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
   </draw:fill-image>
   <style:default-style style:family="graphic">
    <style:graphic-properties svg:stroke-color="#000000" draw:fill-color="#99ccff" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.3cm" draw:shadow-offset-y="0.3cm" draw:start-line-spacing-horizontal="0.283cm" draw:start-line-spacing-vertical="0.283cm" draw:end-line-spacing-horizontal="0.283cm" draw:end-line-spacing-vertical="0.283cm" style:writing-mode="lr-tb" style:flow-with-text="false"/>
-   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0cm" style:writing-mode="lr-tb" style:font-independent-line-spacing="false">
+   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0cm" style:font-independent-line-spacing="false">
     <style:tab-stops/>
    </style:paragraph-properties>
    <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Times New Roman1" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="DejaVu Sans" style:font-size-asian="12pt" style:language-asian="zxx" style:country-asian="none" style:font-name-complex="Lucidasans1" style:font-size-complex="12pt" style:language-complex="zxx" style:country-complex="none"/>
@@ -997,15 +997,15 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:graphic-properties>
   </style:style>
   <style:style style:name="Frame" style:family="graphic">
-   <style:graphic-properties svg:width="17.189cm" fo:min-width="60%" svg:height="14.848cm" fo:min-height="56%" text:anchor-type="paragraph" svg:x="2.702cm" svg:y="0cm" fo:margin-left="0.508cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:run-through="foreground" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph-content" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" fo:background-color="transparent" draw:fill="none" fo:padding="0.152cm" fo:border="0.06pt solid #000000" style:shadow="#000000 0.178cm 0.178cm" draw:shadow-opacity="100%" loext:rel-width-rel="paragraph" loext:rel-height-rel="paragraph">
+   <style:graphic-properties svg:width="17.189cm" fo:min-width="60%" svg:height="14.848cm" fo:min-height="56%" text:anchor-type="paragraph" svg:x="2.702cm" svg:y="0cm" fo:margin-left="0.508cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:run-through="foreground" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph-content" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" fo:background-color="transparent" draw:fill="none" draw:fill-color="#99ccff" fo:padding="0.152cm" fo:border="0.06pt solid #000000" style:shadow="#000000 0.178cm 0.178cm" draw:shadow-opacity="100%" loext:rel-width-rel="paragraph" loext:rel-height-rel="paragraph">
     <style:columns fo:column-count="1" fo:column-gap="0cm"/>
    </style:graphic-properties>
   </style:style>
   <style:style style:name="Formula" style:family="graphic">
-   <style:graphic-properties text:anchor-type="as-char" svg:y="0cm" fo:margin-left="0.051cm" fo:margin-right="0.051cm" style:wrap="parallel" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="middle" style:vertical-rel="text" fo:background-color="transparent" draw:fill="none" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true"/>
+   <style:graphic-properties text:anchor-type="as-char" svg:y="0cm" fo:margin-left="0.051cm" fo:margin-right="0.051cm" style:wrap="parallel" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="middle" style:vertical-rel="text" fo:background-color="transparent" draw:fill="none" draw:fill-color="#99ccff" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true"/>
   </style:style>
   <style:style style:name="OLE" style:family="graphic">
-   <style:graphic-properties text:anchor-type="paragraph" svg:x="0cm" svg:y="0cm" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" fo:background-color="transparent" draw:fill="none"/>
+   <style:graphic-properties text:anchor-type="paragraph" svg:x="0cm" svg:y="0cm" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" fo:background-color="transparent" draw:fill="none" draw:fill-color="#99ccff"/>
   </style:style>
   <text:outline-style style:name="Outline">
    <text:outline-level-style text:level="1" loext:num-list-format="CHAPTER %1%:" style:num-prefix="CHAPTER " style:num-suffix=":" style:num-format="1" text:start-value="8">
@@ -2795,34 +2795,45 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
   <style:style style:name="P43" style:family="paragraph" style:parent-style-name="Table_20_Heading">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="001b8fa1"/>
   </style:style>
-  <style:style style:name="P44" style:family="paragraph" style:parent-style-name="_40_Table_20_Contents">
+  <style:style style:name="P44" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false" style:writing-mode="lr-tb"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="001b8fa1"/>
+  </style:style>
+  <style:style style:name="P45" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="001b8fa1"/>
+  </style:style>
+  <style:style style:name="P46" style:family="paragraph" style:parent-style-name="_40_Table_20_Contents">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties officeooo:paragraph-rsid="14d36d55"/>
   </style:style>
-  <style:style style:name="P45" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
   </style:style>
-  <style:style style:name="P46" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+  </style:style>
+  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" officeooo:rsid="0117c15b" officeooo:paragraph-rsid="0117c15b" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
-  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
-  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" officeooo:paragraph-rsid="13ac3201" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
-  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
-  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties fo:color="#000000" loext:opacity="100%" fo:font-size="9pt" fo:language="en" fo:country="US" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
-  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="Footer">
+  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="Footer">
    <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
     <style:tab-stops>
@@ -2832,7 +2843,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="07061c8d" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
+  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="Footer" style:master-page-name="">
    <loext:graphic-properties draw:fill="none" draw:fill-color="#99ccff"/>
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.203cm" style:contextual-spacing="false" fo:text-align="justify" style:justify-single-word="false" fo:orphans="0" fo:widows="0" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent" style:shadow="none" text:number-lines="false" text:line-number="0">
     <style:tab-stops>
@@ -2842,69 +2853,64 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </style:paragraph-properties>
    <style:text-properties fo:font-weight="normal" officeooo:rsid="001d9905" officeooo:paragraph-rsid="002fc80a" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties officeooo:rsid="003d1478" officeooo:paragraph-rsid="0123e63b"/>
   </style:style>
-  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="0123e63b"/>
   </style:style>
-  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="0125229e"/>
   </style:style>
-  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="0126c6e7"/>
   </style:style>
-  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="0128289a"/>
   </style:style>
-  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P61" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="01299126"/>
   </style:style>
-  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+  <style:style style:name="P62" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties officeooo:rsid="00b0a801" officeooo:paragraph-rsid="012c7fe1"/>
   </style:style>
-  <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+  <style:style style:name="P63" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
    <style:paragraph-properties style:page-number="auto"/>
   </style:style>
-  <style:style style:name="P61" style:family="paragraph" style:parent-style-name="_40_TextBody">
+  <style:style style:name="P64" style:family="paragraph" style:parent-style-name="_40_TextBody">
    <style:text-properties officeooo:paragraph-rsid="001b8fa1"/>
   </style:style>
-  <style:style style:name="P62" style:family="paragraph" style:parent-style-name="Standard">
+  <style:style style:name="P65" style:family="paragraph" style:parent-style-name="Standard">
    <style:text-properties officeooo:paragraph-rsid="001b8fa1"/>
   </style:style>
-  <style:style style:name="P63" style:family="paragraph" style:parent-style-name="Heading_20_3">
+  <style:style style:name="P66" style:family="paragraph" style:parent-style-name="_40_TextBody">
+   <style:text-properties officeooo:paragraph-rsid="001b8fa1"/>
+  </style:style>
+  <style:style style:name="P67" style:family="paragraph" style:parent-style-name="_40_TextBody">
+   <style:text-properties officeooo:rsid="001dc1ac" officeooo:paragraph-rsid="001dc1ac"/>
+  </style:style>
+  <style:style style:name="P68" style:family="paragraph" style:parent-style-name="Heading_20_3">
    <style:paragraph-properties fo:text-align="justify" style:justify-single-word="false" fo:break-before="page"/>
    <style:text-properties fo:language="en" fo:country="US"/>
   </style:style>
-  <style:style style:name="P64" style:family="paragraph" style:parent-style-name="Heading_20_4">
+  <style:style style:name="P69" style:family="paragraph" style:parent-style-name="Heading_20_4">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="001b8fa1"/>
   </style:style>
-  <style:style style:name="P65" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="First_20_Page">
+  <style:style style:name="P70" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="First_20_Page">
    <style:paragraph-properties style:page-number="auto"/>
   </style:style>
-  <style:style style:name="P66" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-  </style:style>
-  <style:style style:name="P67" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
+  <style:style style:name="P71" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="_40_NumberedListTable">
    <style:paragraph-properties style:writing-mode="lr-tb"/>
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="001b8fa1"/>
   </style:style>
-  <style:style style:name="P68" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="L1">
-   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="001b8fa1"/>
-  </style:style>
-  <style:style style:name="P69" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false" style:writing-mode="lr-tb"/>
-   <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="001b8fa1"/>
-  </style:style>
-  <style:style style:name="P70" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+  <style:style style:name="P72" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:list-style-name="L1">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="001b8fa1"/>
   </style:style>
   <style:style style:name="T1" style:family="text">
@@ -4383,7 +4389,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:user-field-decl office:value-type="float" office:value="1" text:name="MD"/>
     <text:user-field-decl office:value-type="string" office:string-value="" text:name="SEQ CHAPTER \h   1"/>
    </text:user-field-decls>
-   <text:p text:style-name="P65"/>
+   <text:p text:style-name="P70"/>
    <text:section text:style-name="Sect1" text:name="WAGHYSTR">
     <text:h text:style-name="P35" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc207827_2026549522"/>WAGHYSTR – Define Water-Alternating-Gas Hysteresis Parameters<text:bookmark-end text:name="__RefHeading___Toc207827_2026549522"/></text:h>
     <table:table table:name="Table1011" table:style-name="Table1011">
@@ -4393,28 +4399,28 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      <table:table-column table:style-name="Table1011.A" table:number-columns-repeated="2"/>
      <table:table-row table:style-name="Table1011.1">
       <table:table-cell table:style-name="Table1011.A1" office:value-type="string">
-       <text:p text:style-name="P53"><text:a xlink:type="simple" xlink:href="#3.RUNSPEC SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">RUNSPEC</text:span></text:a></text:p>
+       <text:p text:style-name="P56"><text:a xlink:type="simple" xlink:href="#3.RUNSPEC SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">RUNSPEC</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1011.A1" office:value-type="string">
-       <text:p text:style-name="P54"><text:a xlink:type="simple" xlink:href="#4.GRID SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">GRID</text:span></text:a></text:p>
+       <text:p text:style-name="P57"><text:a xlink:type="simple" xlink:href="#4.GRID SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">GRID</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1011.A1" office:value-type="string">
-       <text:p text:style-name="P55"><text:a xlink:type="simple" xlink:href="#5.EDIT SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">EDIT</text:span></text:a></text:p>
+       <text:p text:style-name="P58"><text:a xlink:type="simple" xlink:href="#5.EDIT SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">EDIT</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1011.D1" office:value-type="string">
-       <text:p text:style-name="P56"><text:a xlink:type="simple" xlink:href="#6.PROPS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">PROPS</text:span></text:a></text:p>
+       <text:p text:style-name="P59"><text:a xlink:type="simple" xlink:href="#6.PROPS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">PROPS</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1011.A1" office:value-type="string">
-       <text:p text:style-name="P57"><text:a xlink:type="simple" xlink:href="#7.REGIONS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">REGIONS</text:span></text:a></text:p>
+       <text:p text:style-name="P60"><text:a xlink:type="simple" xlink:href="#7.REGIONS SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">REGIONS</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1011.A1" office:value-type="string">
-       <text:p text:style-name="P58"><text:a xlink:type="simple" xlink:href="#8.SOLUTION SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SOLUTION</text:span></text:a></text:p>
+       <text:p text:style-name="P61"><text:a xlink:type="simple" xlink:href="#8.SOLUTION SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SOLUTION</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1011.A1" office:value-type="string">
-       <text:p text:style-name="P58"><text:a xlink:type="simple" xlink:href="#9.SUMMARY SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SUMMARY</text:span></text:a></text:p>
+       <text:p text:style-name="P61"><text:a xlink:type="simple" xlink:href="#9.SUMMARY SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SUMMARY</text:span></text:a></text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1011.H1" office:value-type="string">
-       <text:p text:style-name="P59"><text:a xlink:type="simple" xlink:href="#10.SCHEDULE SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SCHEDULE</text:span></text:a></text:p>
+       <text:p text:style-name="P62"><text:a xlink:type="simple" xlink:href="#10.SCHEDULE SECTION|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T5">SCHEDULE</text:span></text:a></text:p>
       </table:table-cell>
      </table:table-row>
     </table:table>
@@ -4424,7 +4430,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
         <text:p text:style-name="P34">Caudle, B. H., &amp; Dyes, A. B. (1958, January 1). Improving Miscible Displacement by Gas-Water Injection. Society of Petroleum Engineers.</text:p></text:note-body></text:note></text:span><text:span text:style-name="T20">; Christensen et al., 1998</text:span><text:span text:style-name="T20"><text:note text:id="ftn2" text:note-class="footnote"><text:note-citation>2</text:note-citation><text:note-body>
         <text:p text:style-name="P34">Christensen, J. R., Stenby, E. H., &amp; Skauge, A. (1998, January 1). Review of WAG Field Experience. Society of Petroleum Engineers. doi:10.2118/39883-MS.</text:p></text:note-body></text:note></text:span><text:span text:style-name="T20">; and Christensen et al., 2001</text:span><text:span text:style-name="T20"><text:note text:id="ftn3" text:note-class="footnote"><text:note-citation>3</text:note-citation><text:note-body>
         <text:p text:style-name="P34">Christensen, J. R., Stenby, E. H., &amp; Skauge, A. (2001, April 1). Review of WAG Field Experience. Society of Petroleum Engineers. doi:10.2118/71203-PA.</text:p></text:note-body></text:note></text:span><text:span text:style-name="T20">). WAG injection can lead to improved oil recovery by combining better mobility control and contacting upswept zones, and by leading to improved microscopic displacement. Although initially the inject</text:span><text:span text:style-name="T21">ed</text:span><text:span text:style-name="T20"> gas was immiscible with respect to the oil (WAG Immiscible) the more common process is WAG Miscible, with alternating different types of hydrocarbon gases and non-hydrocarbon gases, such as N</text:span><text:span text:style-name="T19">2</text:span><text:span text:style-name="T20"> and CO</text:span><text:span text:style-name="T19">2</text:span><text:span text:style-name="T20"> Gases. <text:s/>WAG flooding has been successfully applied to various fields worldwide.</text:span></text:p>
-    <text:p text:style-name="P61">Only the gas phase relative permeability WAG hysteresis model has been implemented in the simulator.</text:p>
+    <text:p text:style-name="P64">Only the gas phase relative permeability WAG hysteresis model has been implemented in the simulator.</text:p>
     <table:table table:name="Table665" table:style-name="Table665">
      <table:table-column table:style-name="Table665.A"/>
      <table:table-column table:style-name="Table665.B"/>
@@ -4465,7 +4471,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      </table:table-header-rows>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P69">1</text:p>
+       <text:p text:style-name="P44">1</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-rows-spanned="2" office:value-type="string">
        <text:p text:style-name="P41">LANDS_PARAMETER</text:p>
@@ -4728,26 +4734,26 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P70">None</text:p>
+       <text:p text:style-name="P45">None</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:covered-table-cell table:style-name="Table665.C2"/>
       <table:covered-table-cell table:style-name="Table665.C2"/>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:covered-table-cell table:style-name="Table665.F3"/>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P69">2</text:p>
+       <text:p text:style-name="P44">2</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-rows-spanned="2" office:value-type="string">
        <text:p text:style-name="P41">SECONDARY_DRAINAGE_REDUCTION</text:p>
@@ -4759,26 +4765,26 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P70">0.0</text:p>
+       <text:p text:style-name="P45">0.0</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:covered-table-cell table:style-name="Table665.C2"/>
       <table:covered-table-cell table:style-name="Table665.C2"/>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:covered-table-cell table:style-name="Table665.F3"/>
      </table:table-row>
      <table:table-row table:style-name="Table665.7">
       <table:table-cell table:style-name="Table665.A7" office:value-type="string">
-       <text:p text:style-name="P69">3</text:p>
+       <text:p text:style-name="P44">3</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
        <text:p text:style-name="P41">GAS_MODEL</text:p>
@@ -4787,10 +4793,10 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P41">A defined character string that defines whether the gas hysteresis model should be used, and should be set to one of the following character strings:</text:p>
        <text:list text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P67">YES: Use the WAG hysteresis model for the gas phase relative permeability. </text:p>
+         <text:p text:style-name="P71">YES: Use the WAG hysteresis model for the gas phase relative permeability. </text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P67">NO: Turn off the WAG hysteresis model and use the drainage curve.</text:p>
+         <text:p text:style-name="P71">NO: Turn off the WAG hysteresis model and use the drainage curve.</text:p>
         </text:list-item>
        </text:list>
        <text:p text:style-name="P41">Only the YES option is currently supported by the simulator.</text:p>
@@ -4798,13 +4804,13 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" office:value-type="string">
-       <text:p text:style-name="P69">YES</text:p>
+       <text:p text:style-name="P44">YES</text:p>
       </table:table-cell>
      </table:table-row>
      <text:soft-page-break/>
      <table:table-row table:style-name="Table665.7">
       <table:table-cell table:style-name="Table665.A8" office:value-type="string">
-       <text:p text:style-name="P69">4</text:p>
+       <text:p text:style-name="P44">4</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
        <text:p text:style-name="P41">RES_OIL</text:p>
@@ -4813,10 +4819,10 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P41">A defined character string that defines whether the residual oil model should be used, and should be set to one of the following character strings:</text:p>
        <text:list text:continue-numbering="true" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P67">YES: Use the trapped gas to modify the residual oil saturation (SOM) in the STONE 1 three-phase oil relative permeability model. No action is taken unless the STONE1 keyword has been entered. </text:p>
+         <text:p text:style-name="P71">YES: Use the trapped gas to modify the residual oil saturation (SOM) in the STONE 1 three-phase oil relative permeability model. No action is taken unless the STONE1 keyword has been entered. </text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P67">NO: Do not modify the residual oil saturation.</text:p>
+         <text:p text:style-name="P71">NO: Do not modify the residual oil saturation.</text:p>
         </text:list-item>
        </text:list>
        <text:p text:style-name="P41">Only the NO option is currently supported by the simulator.</text:p>
@@ -4824,12 +4830,12 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" office:value-type="string">
-       <text:p text:style-name="P69">YES</text:p>
+       <text:p text:style-name="P44">YES</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.7">
       <table:table-cell table:style-name="Table665.A9" office:value-type="string">
-       <text:p text:style-name="P69">5</text:p>
+       <text:p text:style-name="P44">5</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
        <text:p text:style-name="P41">WATER_MODEL</text:p>
@@ -4838,10 +4844,10 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P41">A defined character string that defines whether the water hysteresis model should be used, and should be set to one of the following character strings:</text:p>
        <text:list text:continue-numbering="true" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P67">YES: Use the WAG hysteresis model for the water phase relative permeability </text:p>
+         <text:p text:style-name="P71">YES: Use the WAG hysteresis model for the water phase relative permeability </text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P67">NO: Turn off the WAG hysteresis model. Note that the hysteresis model specified in EHYSTR keyword applies.</text:p>
+         <text:p text:style-name="P71">NO: Turn off the WAG hysteresis model. Note that the hysteresis model specified in EHYSTR keyword applies.</text:p>
         </text:list-item>
        </text:list>
        <text:p text:style-name="P41">Only the NO option is currently supported by the simulator.</text:p>
@@ -4849,12 +4855,12 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" office:value-type="string">
-       <text:p text:style-name="P69">YES</text:p>
+       <text:p text:style-name="P44">YES</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.7">
       <table:table-cell table:style-name="Table665.A10" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P69">6</text:p>
+       <text:p text:style-name="P44">6</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-rows-spanned="2" office:value-type="string">
        <text:p text:style-name="P41">IMB_LINEAR_FRACTION</text:p>
@@ -4866,26 +4872,26 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P69">0.1</text:p>
+       <text:p text:style-name="P44">0.1</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.7">
       <table:covered-table-cell table:style-name="Table665.A10"/>
       <table:covered-table-cell table:style-name="Table665.C2"/>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:covered-table-cell table:style-name="Table665.F3"/>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:table-cell table:style-name="Table665.C2" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P69">7</text:p>
+       <text:p text:style-name="P44">7</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-rows-spanned="2" office:value-type="string">
        <text:p text:style-name="P41">THREEPHASE_SAT_LIMIT</text:p>
@@ -4898,26 +4904,26 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P69">0.001</text:p>
+       <text:p text:style-name="P44">0.001</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:covered-table-cell table:style-name="Table665.C2"/>
       <table:covered-table-cell table:style-name="Table665.C2"/>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:covered-table-cell table:style-name="Table665.F3"/>
      </table:table-row>
      <table:table-row table:style-name="Table665.7">
       <table:table-cell table:style-name="Table665.A14" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P69">8</text:p>
+       <text:p text:style-name="P44">8</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" table:number-rows-spanned="2" office:value-type="string">
        <text:p text:style-name="P41">RES_OIL_MOD_FRACTION</text:p>
@@ -4930,20 +4936,20 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table665.F3" table:number-rows-spanned="2" office:value-type="string">
-       <text:p text:style-name="P69">1.0</text:p>
+       <text:p text:style-name="P44">1.0</text:p>
       </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table665.1">
       <table:covered-table-cell table:style-name="Table665.A14"/>
       <table:covered-table-cell table:style-name="Table665.C2"/>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.C2" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table665.E15" office:value-type="string">
-       <text:p text:style-name="P70">dimensionless</text:p>
+       <text:p text:style-name="P45">dimensionless</text:p>
       </table:table-cell>
       <table:covered-table-cell table:style-name="Table665.F3"/>
      </table:table-row>
@@ -4952,10 +4958,10 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P42">Notes:</text:p>
        <text:list text:style-name="L1">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P68">The keyword is followed by one record for each saturation table region with each record terminated by a “/”.</text:p>
+         <text:p text:style-name="P72">The keyword is followed by one record for each saturation table region with each record terminated by a “/”.</text:p>
         </text:list-item>
         <text:list-item>
-         <text:p text:style-name="P68">The number of saturation table regions NTSFUN is specified by the TABDIMS keyword in the RUNSPEC section.</text:p>
+         <text:p text:style-name="P72">The number of saturation table regions NTSFUN is specified by the TABDIMS keyword in the RUNSPEC section.</text:p>
         </text:list-item>
        </text:list>
       </table:table-cell>
@@ -4968,7 +4974,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     </table:table>
     <text:p text:style-name="P40">Table <text:sequence text:ref-name="refTable0" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">8.3.364.1</text:sequence>: WAGHYSTR Keyword Description</text:p>
     <text:p text:style-name="P39"/>
-    <text:p text:style-name="P62"/>
+    <text:p text:style-name="P65"/>
     <text:h text:style-name="P38" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc716755_3964674244"/><text:soft-page-break/>Example<text:bookmark-end text:name="__RefHeading___Toc716755_3964674244"/></text:h>
     <text:p text:style-name="P37">The following example defines the WAG hysteresis model parameters using the WAGHYSTR keyword for a case with three saturation table regions</text:p>
     <text:p text:style-name="P36">--</text:p>
@@ -4981,7 +4987,8 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:p text:style-name="P36">2.0 <text:s text:c="5"/>1.0 <text:s text:c="5"/>YES <text:s text:c="3"/>NO <text:s text:c="4"/>/</text:p>
     <text:p text:style-name="P36">2.0 <text:s text:c="5"/>/ <text:s text:c="146"/></text:p>
     <text:p text:style-name="P39"/>
-    <text:p text:style-name="P61">Here, saturation table region one uses the gas WAG hysteresis, residual oil and water WAG hysteresis models, with a Land’s parameter of 2.0, an alpha factor of 1.0, and a imbibition curve linear factor of 0.2. The gas and water WAG hysteresis models are used in region two but the residual oil model is turned off, with a Land’s parameter of 2.0, an alpha factor of 1.0, and a default imbibition curve linear factor of 0.1. A Land’s parameter of 2.0 has been specified for region three with the remainder of the parameters defaulted.</text:p>
+    <text:p text:style-name="P64">Here, saturation table region one uses the gas WAG hysteresis, residual oil and water WAG hysteresis models, with a Land’s parameter of 2.0, an alpha factor of 1.0, and a imbibition curve linear factor of 0.2. The gas and water WAG hysteresis models are used in region two but the residual oil model is turned off, with a Land’s parameter of 2.0, an alpha factor of 1.0, and a default imbibition curve linear factor of 0.1. A Land’s parameter of 2.0 has been specified for region three with the remainder of the parameters defaulted.</text:p>
+    <text:p text:style-name="P67">Note that the above example uses some options that are not currently supported by OPM Flow.</text:p>
     <text:p text:style-name="_40_TextBody"/>
    </text:section>
   </office:text>


### PR DESCRIPTION
Added partial support for WAGHYSTR keyword in the PROPS section (#4710 and #3542). This keyword defines the parameters for the Water-Alternating-Gas (“WAG”) hysteresis option, when the hysteresis option has been activated by the HYSTER variable on the SATOPTS keyword in the RUNSPEC section. Only gas phase hysteresis is currently supported by the WAGHYSTR keyword. The residual oil modification fraction, which would only be active when the STONE1 three-phase oil relative permeability model is used, is not currently supported.