### PR TITLE
Updated remove_bookmarks script

### DIFF
--- a/scripts/src/fodt/xml_helpers.py
+++ b/scripts/src/fodt/xml_helpers.py
@@ -20,10 +20,11 @@ class XMLHelper(object):
         return tag
 
     @staticmethod
-    def starttag(name: str, attrs: dict[str, str]) -> str:
+    def starttag(name: str, attrs: dict[str, str], close_tag: bool = True) -> str:
         result = f"<{name}"
         for (key, value) in attrs.items():
             evalue = xml.sax.saxutils.escape(value)
             result += f" {key}=\"{evalue}\""
-        result += ">"
+        if close_tag:
+            result += ">"
         return result


### PR DESCRIPTION
The remove bookmarks script now uses the short empty element form if an element is empty. This is more in line with what libreoffice does, see discussion in https://github.com/OPM/opm-reference-manual/pull/29#discussion_r1431115738