### PR TITLE
Docker image for libreoffice 7.5

### DIFF
--- a/docker/lo-ubuntu2204/Dockerfile
+++ b/docker/lo-ubuntu2204/Dockerfile
@@ -1,0 +1,41 @@
+# Stage 1: Build LibreOffice
+FROM ubuntu:22.04
+SHELL ["/bin/bash", "-c"]
+
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.dotsrc.org/ubuntu/|g' /etc/apt/sources.list
+
+# Install the runtime dependencies
+# NOTE: x11-xserver-utils is needed for the using the hosts X server to run libreoffice
+ENV TZ=Europe/Oslo
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+        software-properties-common
+# NOTE: it is important to use libreoffice-still (not libreoffice-fresh or ppa)
+#  libreoffice-still gives version 7.5 (whereas libreoffice-fresh gives version 7.6)
+RUN add-apt-repository ppa:libreoffice/libreoffice-still && apt-get update
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+        curl git vim sudo wget tzdata \
+        x11-xserver-utils
+RUN apt-get install -y libreoffice
+
+# clean up the apt cache to reduce the image size
+RUN rm -rf /var/lib/apt/lists/*
+
+ARG user=docker-user
+ARG home=/home/$user
+
+# Add user and set up sudo
+RUN useradd --create-home -s /bin/bash $user \
+        && echo $user:ubuntu | chpasswd \
+        && adduser $user sudo \
+        && echo "$user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+WORKDIR $home
+
+ENV USER=$user
+ENV SHELL=/bin/bash
+USER $user
+
+CMD ["/bin/bash"]
+

--- a/docker/lo-ubuntu2204/build-image.sh
+++ b/docker/lo-ubuntu2204/build-image.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+docker build --network=host -t lo-ubuntu2204 .

--- a/docker/lo-ubuntu2204/docker-soffice.sh
+++ b/docker/lo-ubuntu2204/docker-soffice.sh
@@ -1,0 +1,44 @@
+#! /bin/bash
+
+# This script will run libreoffice 7.5.9 from a Docker container with Ubuntu 22.04
+#
+#  USAGE: ./docker-soffice.sh <file.fodt>
+#
+#  Here, <file.fodt> is the file to be opened in the Docker container.
+#  The file.fodt file must be in the directory "parts" in the root of the repository.
+#  The file will be opened in the Docker container and the container will
+#  be removed when the file is closed.
+#
+#
+#  EXAMPLES:
+#
+#  ./docker-soffice.sh main.fodt          # opens main.fodt in the Docker container
+#  ./docker-soffice.sh appendices/A.fodt  # opens appendices/A.fodt in the Docker container
+#
+#
+# Assume this script is run from the directory containing the Dockerfile
+#  this means that the root of the repository is two levels up
+shared_dir="parts"
+host_directory="$PWD/../../$shared_dir"
+docker_image="lo-ubuntu2204"
+# The home directory of the user in the Docker container
+docker_home="/home/docker-user"
+
+# Check if a file argument is provided
+if [ $# -eq 0 ]; then
+    echo "No file provided. Usage: ./docker-soffice.sh <file.fodt>"
+    exit 1
+fi
+
+# Allow Docker Container to Access the Host's X Server
+# Temporarily allow connections from any client
+xhost +
+# Run soffice in the Docker container
+docker run -v "${host_directory}:${docker_home}/$shared_dir" \
+           --rm \
+           -e DISPLAY=$DISPLAY \
+           -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+           $docker_image \
+           libreoffice "$docker_home/$shared_dir/$1"
+# Revoke the X11 access
+xhost -


### PR DESCRIPTION
See #91 for background.

As a workaround for #91 this `Dockerfile` can be used to build an image for libreoffice 7.5.9 on Ubuntu 22.04. The image can then be run in a docker container to view the `main.fodt` file on Ubuntu 23.10. (Tested on my laptop with Ubuntu 23.10, and seems to work fine here)