### PR TITLE
Added a raw bash script to review differences made to the text.

### DIFF
--- a/scripts/text-diff.sh
+++ b/scripts/text-diff.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+echo $1 $2
+git checkout main
+git fetch origin pull/$1/head:$2
+dir="."
+if test "$#" -gt "2"; then
+    dir="$3"
+fi
+file=$(find $dir -name $2.fodt)
+CHANGED=0
+if test -n "$file"; then
+  CHANGED=1
+  libreoffice --headless --convert-to txt:Text $file --outdir /tmp/
+  mv /tmp/$2.txt /tmp/"$2"_old.txt
+fi
+git checkout $2
+if test "$CHANGED" -eq "1"; then
+  libreoffice --headless --convert-to txt:Text $file --outdir /tmp/
+  diff /tmp/"$2"_old.txt  /tmp/$2.txt
+  libreoffice parts/main.fodt
+else
+  file=$(find . -name $2.fodt)
+  if test -z "$file"; then
+    libreoffice $file
+  fi
+fi


### PR DESCRIPTION
scripts/text-diff.sh is totally unpolished and might fail in various occasions. Still, it rather handy to detect and review differences made to the text in a subdocument.

Arguments are the PR number and the base name of the changed file. It will checkout main, convert the file to txt and store it as basename_old.txt in /tmp. Then it will checkout the PR, convert the updated document to txt in file /tmp/basename.txt. Execute diff on those two files and start liberoffice with the main file.