### PR TITLE
Escape quotes and apostrophes when writing XML files with the Python scripts

### DIFF
--- a/scripts/python/src/fodt/add_keyword.py
+++ b/scripts/python/src/fodt/add_keyword.py
@@ -46,10 +46,10 @@ class AppendixHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if self.in_styles:
-            self.content.write(xml.sax.saxutils.escape(content))
+            self.content.write(XMLHelper.escape(content))
         elif self.in_appendix_table:
             if self.in_table_row:
-                self.current_row.write(xml.sax.saxutils.escape(content))
+                self.current_row.write(XMLHelper.escape(content))
             else:
                 self.between_rows += content
                 # Capture stuff between the rows, such that we
@@ -64,7 +64,7 @@ class AppendixHandler(xml.sax.handler.ContentHandler):
                     self.current_table_number += 1
                     if self.current_table_number == self.keyword_table_number:
                         self.found_appendix_table = True
-            self.content.write(xml.sax.saxutils.escape(content))
+            self.content.write(XMLHelper.escape(content))
 
     def endElement(self, name: str):
         if name == "table:table-cell":

--- a/scripts/python/src/fodt/add_keyword_status.py
+++ b/scripts/python/src/fodt/add_keyword_status.py
@@ -37,7 +37,7 @@ class AppendixStatusColorHandler(xml.sax.handler.ContentHandler):
         self.green_styles = set()
 
     def characters(self, content: str):
-        self.content.write(xml.sax.saxutils.escape(content))
+        self.content.write(XMLHelper.escape(content))
 
     def collect_table_cell_styles(self, attrs: xml.sax.xmlreader.AttributesImpl) -> None:
         # collect the style names for orange and green colors

--- a/scripts/python/src/fodt/automatic_styles_filter.py
+++ b/scripts/python/src/fodt/automatic_styles_filter.py
@@ -52,7 +52,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if self.include:
-            self.content.write(xml.sax.saxutils.escape(content))
+            self.content.write(XMLHelper.escape(content))
 
 
 class AutomaticStylesFilter:

--- a/scripts/python/src/fodt/extract_appendix.py
+++ b/scripts/python/src/fodt/extract_appendix.py
@@ -121,9 +121,9 @@ class ExtractAndRemoveHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if self.in_appendix:
-            self.appendix.write(xml.sax.saxutils.escape(content))
+            self.appendix.write(XMLHelper.escape(content))
         else:
-            self.doc.write(xml.sax.saxutils.escape(content))
+            self.doc.write(XMLHelper.escape(content))
 
     def collect_styles(self, attrs: xml.sax.xmlreader.AttributesImpl) -> None:
         for (key, value) in attrs.items():

--- a/scripts/python/src/fodt/extract_chapters.py
+++ b/scripts/python/src/fodt/extract_chapters.py
@@ -70,7 +70,7 @@ class ChapterHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if self.in_section:
-            self.section.write(xml.sax.saxutils.escape(content))
+            self.section.write(XMLHelper.escape(content))
 
     def patch_chapter_12(self, path: Path) -> None:
         with open(path, "r", encoding='utf8') as f:

--- a/scripts/python/src/fodt/extract_fonts.py
+++ b/scripts/python/src/fodt/extract_fonts.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import click
 
 from fodt.exceptions import HandlerDoneException
+from fodt.xml_helpers import XMLHelper
 
 class FontHandler(xml.sax.handler.ContentHandler):
     def __init__(self, save_dir: Path) -> None:
@@ -29,7 +30,7 @@ class FontHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if self.in_binary_data:
-            self.font_data.write(xml.sax.saxutils.escape(content))
+            self.font_data.write(XMLHelper.escape(content))
 
     def endElement(self, name: str):
         if self.in_binary_data and name == 'office:binary-data':

--- a/scripts/python/src/fodt/extract_metadata.py
+++ b/scripts/python/src/fodt/extract_metadata.py
@@ -91,7 +91,7 @@ class SectionHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if self.in_section:
-            self.content.write(xml.sax.saxutils.escape(content))
+            self.content.write(XMLHelper.escape(content))
 
     def write_section_to_file(self):
         filename = self.current_section.removeprefix("office:") + ".xml"

--- a/scripts/python/src/fodt/extract_section.py
+++ b/scripts/python/src/fodt/extract_section.py
@@ -121,9 +121,9 @@ class ExtractAndRemoveHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if self.in_section:
-            self.section.write(xml.sax.saxutils.escape(content))
+            self.section.write(XMLHelper.escape(content))
         else:
-            self.doc.write(xml.sax.saxutils.escape(content))
+            self.doc.write(XMLHelper.escape(content))
 
     def collect_styles(self, attrs: xml.sax.xmlreader.AttributesImpl) -> None:
         for (key, value) in attrs.items():

--- a/scripts/python/src/fodt/extract_subsections.py
+++ b/scripts/python/src/fodt/extract_subsections.py
@@ -62,7 +62,7 @@ class PartsHandler(xml.sax.handler.ContentHandler):
                 self.keyword_name = self.predefined_keywords[self.current_subsection - 1]
             self.save_keyword_name = False
         if self.in_subsection:
-            self.subsection.write(xml.sax.saxutils.escape(content))
+            self.subsection.write(XMLHelper.escape(content))
 
     def collect_styles(self, attrs: xml.sax.xmlreader.AttributesImpl) -> None:
         for (key, value) in attrs.items():

--- a/scripts/python/src/fodt/extract_tag_attrs.py
+++ b/scripts/python/src/fodt/extract_tag_attrs.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from fodt.constants import Directories, FileNames
 from fodt.exceptions import HandlerDoneException
+from fodt.xml_helpers import XMLHelper
 
 class TagHandler(xml.sax.handler.ContentHandler):
     def __init__(self, tag_name: str) -> None:
@@ -53,6 +54,6 @@ class ExtractDocAttrs():
                 f"will overwrite...")
         with open(filename, "w", encoding='utf-8') as f:
             for (key, value) in attrs.items():
-                evalue = xml.sax.saxutils.escape(value)
+                evalue = XMLHelper.escape(value)
                 f.write(f'{key}="{evalue}"\n')
         logging.info(f"Wrote document attributes to {filename}.")

--- a/scripts/python/src/fodt/extract_xml_tag.py
+++ b/scripts/python/src/fodt/extract_xml_tag.py
@@ -69,7 +69,7 @@ class SectionHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if self.in_section:
-            self.section += xml.sax.saxutils.escape(content)
+            self.section += XMLHelper.escape(content)
 
     def remove_trailing_spaces(self):
         self.section = re.sub(r"\s+$", "", self.section)

--- a/scripts/python/src/fodt/helpers.py
+++ b/scripts/python/src/fodt/helpers.py
@@ -5,6 +5,7 @@ import xml.sax.saxutils
 from pathlib import Path
 from fodt.constants import Directories, FileExtensions, FileNames
 from fodt.exceptions import InputException
+from fodt.xml_helpers import XMLHelper
 
 class Helpers:
 
@@ -103,7 +104,7 @@ class Helpers:
     def replace_section_callback(part: str, keyword: str) -> str:
         section = ".".join(part.split(".")[:2])
         href = f"{Directories.subsections}/{section}/{keyword}.fodt"
-        href = xml.sax.saxutils.escape(href)
+        href = XMLHelper.escape(href)
         return (f"""<text:section text:style-name="Sect1" text:name="Section{section}:{keyword}" """
                    f"""text:protected="true">\n"""
                 f"""     <text:section-source xlink:href="{href}" """

--- a/scripts/python/src/fodt/remove_bookmarks.py
+++ b/scripts/python/src/fodt/remove_bookmarks.py
@@ -30,7 +30,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
             # tag and the end tag. If there is no content, characters() is not called.
             self.content.write(">")
             self.start_tag_open = False
-        self.content.write(xml.sax.saxutils.escape(content))
+        self.content.write(XMLHelper.escape(content))
 
     def endElement(self, name: str):
         if self.in_master_styles:

--- a/scripts/python/src/fodt/remove_chapters.py
+++ b/scripts/python/src/fodt/remove_chapters.py
@@ -35,7 +35,7 @@ class ChapterHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if not self.in_section:
-            self.content.write(xml.sax.saxutils.escape(content))
+            self.content.write(XMLHelper.escape(content))
 
     def default_replace_callback(self, section: int) -> str:
         return f"<text:section>Section{section}</text:section>\n"

--- a/scripts/python/src/fodt/remove_elements.py
+++ b/scripts/python/src/fodt/remove_elements.py
@@ -63,7 +63,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if not self.in_element:
-            self.content.write(xml.sax.saxutils.escape(content))
+            self.content.write(XMLHelper.escape(content))
 
     def write_file(self):
         filename = Path(self.outputfn)

--- a/scripts/python/src/fodt/remove_fonts.py
+++ b/scripts/python/src/fodt/remove_fonts.py
@@ -24,7 +24,7 @@ class FontHandler(xml.sax.handler.ContentHandler):
     def characters(self, content: str):
         if self.in_font_face:
             return  # we remove the interior of a font-face tag
-        self.content.write(xml.sax.saxutils.escape(content))
+        self.content.write(XMLHelper.escape(content))
 
     def endElement(self, name: str):
         if name == 'office:font-face-decls':

--- a/scripts/python/src/fodt/remove_subsections.py
+++ b/scripts/python/src/fodt/remove_subsections.py
@@ -40,7 +40,7 @@ class PartsHandler(xml.sax.handler.ContentHandler):
     def characters(self, content: str):
         # if (not self.in_subsection) and (not self.remove_section):
         if not self.in_main_section:
-            self.content.write(xml.sax.saxutils.escape(content))
+            self.content.write(XMLHelper.escape(content))
 
     def check_included_section(self, name: str, attrs: xml.sax.xmlreader.AttributesImpl) -> bool:
         if "text:name" in attrs.getNames():

--- a/scripts/python/src/fodt/set_fonts.py
+++ b/scripts/python/src/fodt/set_fonts.py
@@ -45,7 +45,7 @@ class ItemHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if not self.in_section:
-            self.content.write(xml.sax.saxutils.escape(content))
+            self.content.write(XMLHelper.escape(content))
 
     def write_file(self):
         with open(self.savename, "w", encoding='utf-8') as f:

--- a/scripts/python/src/fodt/split_main.py
+++ b/scripts/python/src/fodt/split_main.py
@@ -23,7 +23,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
         self.nesting = 0
 
     def characters(self, content: str):
-        self.content.write(xml.sax.saxutils.escape(content))
+        self.content.write(XMLHelper.escape(content))
 
     def check_correct_table(self, attrs: xml.sax.xmlreader.AttributesImpl) -> bool:
         keys = attrs.keys()

--- a/scripts/python/src/fodt/styles_filter.py
+++ b/scripts/python/src/fodt/styles_filter.py
@@ -19,7 +19,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         self.content.write(f"<{name}")
         for (key, value) in attrs.items():
-            evalue = xml.sax.saxutils.escape(value)
+            evalue = XMLHelper.escape(value)
             self.content.write(f" {key}=\"{evalue}\"")
         if name == "text:outline-level-style":
             level = int(attrs.getValue("text:level"))
@@ -34,7 +34,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
         self.content.write(XMLHelper.endtag(name))
 
     def characters(self, content: str):
-        self.content.write(xml.sax.saxutils.escape(content))
+        self.content.write(XMLHelper.escape(content))
 
 class StylesFilter:
     def __init__(self, content: str, part: str) -> None:

--- a/scripts/python/src/fodt/xml_helpers.py
+++ b/scripts/python/src/fodt/xml_helpers.py
@@ -5,10 +5,19 @@ from fodt.constants import FileNames
 
 class XMLHelper(object):
     header = """<?xml version="1.0" encoding="UTF-8"?>\n"""
-
+    # NOTE: xml.sax.saxutils.escape() escapes only the three characters
+    # "&", "<", ">". But LibreOffice also escapes the characters '"', "'" so
+    # we need to escape them as well in order to not get large PR diffs when
+    # modifying the .fodt files sometimes with a script and sometimes with
+    # LibreOffice.
+    escape_map = {'"': '&quot;', "'": '&apos;'}
     @staticmethod
     def endtag(name: str) -> str:
         return f"</{name}>"
+
+    @staticmethod
+    def escape(content: str) -> str:
+        return xml.sax.saxutils.escape(content, XMLHelper.escape_map)
 
     @staticmethod
     def get_office_document_start_tag(metadir: Path) -> None:
@@ -23,7 +32,7 @@ class XMLHelper(object):
     def starttag(name: str, attrs: dict[str, str], close_tag: bool = True) -> str:
         result = f"<{name}"
         for (key, value) in attrs.items():
-            evalue = xml.sax.saxutils.escape(value)
+            evalue = XMLHelper.escape(value)
             result += f" {key}=\"{evalue}\""
         if close_tag:
             result += ">"


### PR DESCRIPTION
`xml.sax.saxutils.escape()` escapes only the three characters `&`, `<`, and `>`. But LibreOffice also escapes the characters `"` and `'`. So we should escape them as well in order not to get large PR diffs each time a Python script is modifying the XML files. Or each time LibreOffice is modifying an XML file that was previously written by a Python script.