### PR TITLE
Added a more advanced method to locate the maindir from the Python scripts

### DIFF
--- a/scripts/python/src/fodt/constants.py
+++ b/scripts/python/src/fodt/constants.py
@@ -9,7 +9,7 @@ class ClickOptions():
         '--filename',
         envvar='FODT_FILENAME',
         required=True,
-        help='Name of the FODT file to extract from.'
+        help='Name of the FODT file to extract from. Used in combination with the --maindir option. This can be an absolute path or a relative path. If the filename is an absolute path, the --maindir option is ignored and the filename is used as is. If the filename is a relative path, and not found by concatenating maindir and filename it is searched for relative to the current working directory. If found, maindir is derived from the filename by searching its parent directories for a file main.fodt.'
     )(func)
     keyword_dir = lambda func: click.option(
         '--keyword-dir',
@@ -27,7 +27,7 @@ class ClickOptions():
                 required=required,
                 default=default,
                 type=str,
-                help='Directory to save generated files.'
+                help='Directory where the main.fodt file is located. Often used in combination with the --filename option. Defaults to ../../parts (this default is based on that it is likely the user will run the script from the scripts/python directory) The environment variable FODT_MAIN_DIR can also be used to provide this value. If the filename is an absolute path, this option is ignored and maindir is derived from the filename by searching its parent directories for a file main.fodt. If the filename is a relative path, and not found by concatenating maindir and filename it is searched for relative to the current working directory. If found, maindir is derived from the filename by searching its parent directories for a file main.fodt.'
             )(func)
         return decorator
 
@@ -38,6 +38,7 @@ class Directories():
     keywords = "keywords"
     meta = "meta"
     meta_sections = "sections"
+    parts = "parts"
     styles = "styles"
     chapters = "chapters"
     sections = "sections"

--- a/scripts/python/src/fodt/remove_span_tags.py
+++ b/scripts/python/src/fodt/remove_span_tags.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import click
 
 from fodt.constants import ClickOptions
+from fodt.helpers import Helpers
 from fodt.xml_helpers import XMLHelper
 
 class RemoveEmptyLinesHandler(xml.sax.handler.ContentHandler):
@@ -346,4 +347,5 @@ def remove_version_span_tags(
 ) -> None:
     """Remove version span tags from all .fodt subdocuments."""
     logging.basicConfig(level=logging.INFO)
+    maindir, filename = Helpers.locate_maindir_and_filename(maindir, filename)
     RemoveSpanTags(maindir, filename, max_files).remove_span_tags()

--- a/scripts/python/src/fodt/remove_span_tags.py
+++ b/scripts/python/src/fodt/remove_span_tags.py
@@ -257,6 +257,9 @@ class RemoveSpanTags:
         self.maindir = Path(maindir)
         self.filename = filename
         self.max_files = max_files
+        assert self.maindir.is_absolute()
+        assert self.filename is None or Path(self.filename).is_absolute()
+        assert self.maindir.is_dir()
 
     def remove_empty_lines(self, filename: Path) -> None:
         # Remove empty lines from the automtic-styles section
@@ -269,7 +272,8 @@ class RemoveSpanTags:
 
     def remove_span_tags(self) -> None:
         if self.filename:
-            self.remove_span_tags_and_styles_from_file(self.maindir / self.filename)
+            # NOTE: self.filename is an absolute path
+            self.remove_span_tags_and_styles_from_file(self.filename)
         else:
             self.remove_span_tags_from_all_files()
 
@@ -347,5 +351,13 @@ def remove_version_span_tags(
 ) -> None:
     """Remove version span tags from all .fodt subdocuments."""
     logging.basicConfig(level=logging.INFO)
-    maindir, filename = Helpers.locate_maindir_and_filename(maindir, filename)
+    if filename is not None:
+        filename = Path(filename)
+        assert filename.is_absolute()
+        maindir, filename = Helpers.locate_maindir_and_filename(maindir, filename)
+    else:
+        # Convert maindir to an absolute path
+        maindir = Helpers.get_maindir(maindir)
+        maindir = Path(maindir).absolute()
+        assert maindir.is_dir()
     RemoveSpanTags(maindir, filename, max_files).remove_span_tags()

--- a/scripts/python/tests/test_helpers.py
+++ b/scripts/python/tests/test_helpers.py
@@ -1,0 +1,89 @@
+import os
+from pathlib import Path
+
+import pytest
+from fodt.constants import Directories, FileNames
+from fodt.helpers import Helpers
+
+class TestLocateMainDir:
+    def test_locate_with_absolute_path_exists(self, tmp_path: Path) -> None:
+        """Test locating maindir and filename when the maindir is given as an absolute path."""
+        maindir = tmp_path / Directories.parts
+        maindir.mkdir()
+        mainfile = maindir / FileNames.main_document
+        mainfile.touch()
+        filename_dir = maindir / Directories.chapters
+        filename_dir.mkdir()
+        filename = filename_dir / "1.fodt"
+        filename.touch()
+        result_maindir, result_filename = Helpers.locate_maindir_and_filename(
+            str(maindir), str(filename)
+        )
+        assert result_maindir == maindir
+        assert result_filename == filename
+
+    def test_locate_with_absolute_path_exists_no_main(self, tmp_path: Path) -> None:
+        maindir = tmp_path / Directories.parts
+        maindir.mkdir()
+        mainfile = maindir / FileNames.main_document
+        # mainfile.touch()  # Do not create the main file
+        filename_dir = maindir / Directories.chapters
+        filename_dir.mkdir()
+        filename = filename_dir / "1.fodt"
+        filename.touch()
+        with pytest.raises(FileNotFoundError) as excinfo:
+            Helpers.locate_maindir_and_filename(
+                str(maindir), str(filename)
+            )
+        assert (f"Could not find '{FileNames.main_document}' in a directory "
+                f"called '{Directories.parts}'" in str(excinfo.value))
+
+    def test_locate_with_relative_path_in_maindir_exists(self, tmp_path: Path) -> None:
+        maindir = tmp_path / Directories.parts
+        maindir.mkdir()
+        mainfile = maindir / FileNames.main_document
+        mainfile.touch()  # Ensure the main document exists
+        # Change directory to maindir
+        os.chdir(str(maindir))
+        filename_dir = Path(Directories.appendices)
+        filename_dir.mkdir()
+        filename = "A.fodt"
+        filename_path = filename_dir / filename
+        filename_path.touch()  # Create the file within maindir
+        filename_abs_path = maindir / filename_path
+        result_maindir, result_filename = Helpers.locate_maindir_and_filename(
+            str(maindir), str(filename_path)
+        )
+        assert result_maindir == maindir
+        assert result_filename == filename_abs_path
+
+    def test_locate_with_relative_path_not_in_maindir_but_in_cwd(
+            self, tmp_path: Path
+    ):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        os.chdir(str(cwd))
+        filename = "1.fodt"
+        filename_path = cwd / filename
+        filename_path.touch()  # Create the file in CWD
+        maindir = tmp_path  # Some dummy path that is not the maindir
+        with pytest.raises(FileNotFoundError) as excinfo:
+            Helpers.locate_maindir_and_filename(
+                str(maindir), str(filename_path)
+            )
+        assert excinfo.match(
+            f"Could not find '{FileNames.main_document}' in a directory "
+            f"called '{Directories.parts}' by searching the parent "
+            f"directories of filename."
+        )
+
+    def test_locate_with_absolute_path_not_exists(self, tmp_path: Path):
+        maindir = tmp_path / Directories.parts
+        maindir.mkdir()
+        filename = tmp_path / "nonexistent.fodt"
+        # Do not create the file, simulating a non-existent file scenario
+
+        with pytest.raises(AssertionError):
+            Helpers.locate_maindir_and_filename(
+                str(maindir), str(filename)
+            )

--- a/scripts/python/tests/test_helpers.py
+++ b/scripts/python/tests/test_helpers.py
@@ -5,7 +5,7 @@ import pytest
 from fodt.constants import Directories, FileNames
 from fodt.helpers import Helpers
 
-class TestLocateMainDir:
+class TestLocateMainDirAndFilename:
     def test_locate_with_absolute_path_exists(self, tmp_path: Path) -> None:
         """Test locating maindir and filename when the maindir is given as an absolute path."""
         maindir = tmp_path / Directories.parts
@@ -87,3 +87,40 @@ class TestLocateMainDir:
             Helpers.locate_maindir_and_filename(
                 str(maindir), str(filename)
             )
+
+class TestLocateMainDirFromCwd:
+    def test_locate_exists_in_cwd(self, tmp_path: Path):
+        """Test locating maindir from the current working directory when the maindir
+        exists in the current working directory."""
+        maindir = tmp_path / Directories.parts
+        maindir.mkdir()
+        mainfile = maindir / FileNames.main_document
+        mainfile.touch()
+        os.chdir(str(tmp_path))
+        result = Helpers.locate_maindir_from_current_dir()
+        assert result == maindir
+
+    def test_locate_exists_as_parent(self, tmp_path: Path):
+        """Test locating maindir from the current working directory when the maindir
+        is the parent of the current working directory."""
+        maindir = tmp_path / Directories.parts
+        maindir.mkdir()
+        mainfile = maindir / FileNames.main_document
+        mainfile.touch()
+        os.chdir(str(maindir))
+        result = Helpers.locate_maindir_from_current_dir()
+        assert result == maindir
+
+    def test_locate_exists_as_sibling_of_parent(self, tmp_path: Path):
+        """Test locating maindir from the current working directory when the maindir
+        is a sibling of the parent of the current working directory."""
+        maindir = tmp_path / Directories.parts
+        maindir.mkdir()
+        mainfile = maindir / FileNames.main_document
+        mainfile.touch()
+        os.chdir(str(tmp_path))
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        os.chdir(str(subdir))
+        result = Helpers.locate_maindir_from_current_dir()
+        assert result == maindir


### PR DESCRIPTION
For background see #209.

Added a more advanced method to locate the `maindir` and `filename` arguments for usage with the Python scripts. This is useful because the Python scripts can be installed globally and then run from any directory. The original logic assumed that the Python scripts were run from `scripts/python`. Also added some unit tests.