### PR TITLE
Fixes run_container with installed scripts.

### DIFF
--- a/docker/src/lodocker/run_container.py
+++ b/docker/src/lodocker/run_container.py
@@ -15,6 +15,8 @@ class RunContainer:
     def __init__(self):
         self.shared_doc_dir = "parts"
         self.git_root = Path(__file__).resolve().parents[3]
+        if not Path(self.git_root, '.git').is_dir():
+            self.git_root = Path(__file__).resolve().parents[5]
         logging.info(f"git_root: {self.git_root}")
         self.document_dir = self.git_root / self.shared_doc_dir
         # The home directory of the user in the Docker container


### PR DESCRIPTION
In that case the scripts are installed below
venv/lib/python3.?/site-packages and we need to go further up the directory tree.

Closes #213 