### PR TITLE
Update the set-keyword-status script

### DIFF
--- a/scripts/python/README.md
+++ b/scripts/python/README.md
@@ -52,7 +52,7 @@ To change the status of a keyword in the status column in the alphabetical listi
 of keywords in Appendix A, run for example:
 
 ```
-$ fodt-set-ketword-status --keyword=CSKIN --color=green --opm-flow
+$ fodt-set-keyword-status --keyword=CSKIN --color=green --opm-flow
 ```
 
 this will change the color from orange to green and add the text "OPM Flow" to indicate

--- a/scripts/python/README.md
+++ b/scripts/python/README.md
@@ -48,14 +48,16 @@ the heading with the keyword name.
 
 ## Changing the status of a keyword in Appendix A
 
-To change the status color of a keyword in the status column in the alphabetical listing of keywords
-in Appendix A, run for example:
+To change the status of a keyword in the status column in the alphabetical listing
+of keywords in Appendix A, run for example:
 
 ```
-$ fodt-set-ketword-status --keyword=CSKIN --color=green
+$ fodt-set-ketword-status --keyword=CSKIN --color=green --opm-flow
 ```
 
-this will change the color from orange to green.
+this will change the color from orange to green and add the text "OPM Flow" to indicate
+that the keyword is specific to OPM flow. If the keyword is not specific to OPM flow,
+just omit the `--opm-flow` flag.
 
 ## Submitting a PR for a change to a `.fodt` file
 

--- a/scripts/python/src/fodt/add_keyword_status.py
+++ b/scripts/python/src/fodt/add_keyword_status.py
@@ -216,22 +216,22 @@ class UpdateKeywordStatus:
 @click.command()
 @ClickOptions.maindir(required=False)
 @click.option("--keyword", type=str, required=True, help="Keyword to change status for.")
-@click.option("--status", type=str, required=True, help="New status for keyword.")
+@click.option("--color", type=str, required=True, help="New status color for keyword.")
 @click.option("--opm-flow", type=bool, default=False, is_flag=True, help="Flow specific keyword")
 def set_keyword_status(
     maindir: str,
     keyword: str,
-    status: str,
+    color: str,
     opm_flow: bool
 ) -> None:
     """Change the status of a keyword in Appendix A."""
     logging.basicConfig(level=logging.INFO)
     try:
-        status = KeywordStatus[status.upper()]
+        color = KeywordStatus[color.upper()]
     except ValueError:
         raise ValueError(f"Invalid status value: {status}.")
-    logging.info(f"Updating parameters for keyword {keyword}:  Status: {status}, flow-specific keyword: {opm_flow}.")
-    UpdateKeywordStatus(maindir, keyword, status, opm_flow).update()
+    logging.info(f"Updating parameters for keyword {keyword}:  Color: {color}, flow-specific keyword: {opm_flow}.")
+    UpdateKeywordStatus(maindir, keyword, color, opm_flow).update()
 
 if "__name__" == "__main__":
     set_keyword_status()


### PR DESCRIPTION
Updated the `fodt-set-keyword-status` script to also handle the case when keyword is specific to OPM flow:

![image](https://github.com/OPM/opm-reference-manual/assets/6708379/b30ce1e2-63fe-468a-bd87-96854c1e18c7)

when the keyword is specific to OPM flow, the text "OPM Flow" is shown in the table as shown in the screenshot above. The script can now be run like this:

```
$  fodt-set-ketword-status --keyword=CSKIN --color=green --opm-flow
```
to put the text "OPM Flow" or just omit the flag `--opm-flow` to remove the text "OPM Flow".

Thanks to @gdfldm for the suggestion.

@gdfldm Can you test this?
