### PR TITLE
Added script to clean up meta files

### DIFF
--- a/scripts/python/pyproject.toml
+++ b/scripts/python/pyproject.toml
@@ -43,6 +43,7 @@ fodt-split-subdocument = "fodt.split_subdocument:split_subdocument"
 fodt-splitter = "fodt.splitter:main"
 fodt-validate-document = "fodt.validate_automatic_styles:validate"
 fodt-xml-sax-filter-all = "fodt.xml_sax_filter_all:xml_sax_filter_all"
+fodt-xml-sax-filter-meta = "fodt.xml_filter_meta:xml_sax_filter_meta"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/python/src/fodt/xml_filter_meta.py
+++ b/scripts/python/src/fodt/xml_filter_meta.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import click
 
-from fodt.constants import ClickOptions
+from fodt.constants import ClickOptions, Directories, FileExtensions
 from fodt.xml_handlers import PassThroughFilterHandler
 
 
@@ -16,7 +16,11 @@ class FilterAll:
         self.maindir = Path(maindir)
 
     def run_filter(self) -> None:
-        for i, filename in enumerate(self.maindir.rglob("*.fodt"), start=1):
+        meta_dir = self.maindir / Directories.meta / Directories.sections
+        if not meta_dir.is_dir():
+            logging.info(f"Directory {meta_dir} does not exist.")
+            return
+        for i, filename in enumerate(meta_dir.glob("*.xml"), start=1):
             logging.info(f"Processing file: {filename}")
             self.filter_file(filename)
             #if i == 1:
@@ -34,21 +38,24 @@ class FilterAll:
 
 # USAGE:
 #
-#   fodt-xml-sax-filter-all \
+#   fodt-xml-sax-filter-meta \
 #        --maindir=<main directory> \
 #
 # DESCRIPTION:
 #
-#  Runs xml.sax filter on all .fodt files in the main directory. This means that
-#  each .fodt file is read by the xml.sax parser, and the content is then written back
-#  to the file using xml.sax.saxutils.escape() to escape the content.
-#  This is useful to check for inconsistencies in the XML content written by LibreOffice
+#    Runs xml.sax pass-through filter on all xml files in the parts/meta/sections
+#  directory. The files in this directory are used by among other the
+#  fodt-add-keyword script.
+#    This means that each xml file is read by the xml.sax parser, and
+#  the content is then written back to the file using xml.sax.saxutils.escape()
+#  to escape the content.
+#    This is useful to check for inconsistencies in the XML content written by LibreOffice
 #  and the content written by the xml.sax parser and to initially algin the XML content
 #  with the format written by LibreOffice.
 #
 @click.command()
 @ClickOptions.maindir(required=False)
-def xml_sax_filter_all(maindir: str) -> None:
-    """Filter all .fodt files in maindir."""
+def xml_sax_filter_meta(maindir: str) -> None:
+    """Filter all xml files in the meta dir."""
     logging.basicConfig(level=logging.INFO)
     FilterAll(maindir).run_filter()


### PR DESCRIPTION
Added script to run xml pass-through filter on the xml meta files. These files are used by the add-keyword script. So we should cleanup the meta files the same way we did for the .fodt files in https://github.com/OPM/opm-reference-manual/pull/172