### PR TITLE
Fixed bug in fodt-xml-sax-filter-meta script

### DIFF
--- a/parts/meta/sections/font-face-decls.xml
+++ b/parts/meta/sections/font-face-decls.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <office:font-face-decls>
   <style:font-face style:name="StarSymbol" svg:font-family="StarSymbol" style:font-charset="x-symbol"/>
   <style:font-face style:name="BernhardMod BT Roman" svg:font-family="&apos;BernhardMod BT Roman&apos;"/>

--- a/parts/meta/sections/master-styles.xml
+++ b/parts/meta/sections/master-styles.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <office:master-styles>
   <style:master-page style:name="Standard" style:page-layout-name="pm1"/>
   <style:master-page style:name="First_20_Page" style:display-name="First Page" style:page-layout-name="pm2" draw:style-name="dp1" style:next-style-name="Standard"/>

--- a/parts/meta/sections/meta.xml
+++ b/parts/meta/sections/meta.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <office:meta><meta:creation-date>2023-05-18T17:05:55.227000000</meta:creation-date><meta:editing-duration>PT5H27M43S</meta:editing-duration><meta:editing-cycles>23</meta:editing-cycles><meta:generator>LibreOffice/7.0.4.2$Linux_X86_64 LibreOffice_project/00$Build-2</meta:generator><dc:subject>OPM Flow Reference Manual</dc:subject><dc:title>OPEN POROUS MEDIA</dc:title><dc:description>To insert equations with numbing and correct Table layout type
 1) eq 
 2) F3

--- a/parts/meta/sections/scripts.xml
+++ b/parts/meta/sections/scripts.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <office:scripts>
   <office:script script:language="ooo:Basic">
    <ooo:libraries xmlns:ooo="http://openoffice.org/2004/office" xmlns:xlink="http://www.w3.org/1999/xlink"/>

--- a/parts/meta/sections/settings.xml
+++ b/parts/meta/sections/settings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
    <config:config-item config:name="ViewAreaTop" config:type="long">0</config:config-item>

--- a/parts/meta/sections/styles.xml
+++ b/parts/meta/sections/styles.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <office:styles>
   <draw:gradient draw:name="Gradient_20_1" draw:display-name="Gradient 1" draw:style="linear" draw:start-color="#000000" draw:end-color="#ffffff" draw:start-intensity="100%" draw:end-intensity="100%" draw:angle="0deg" draw:border="0%"/>
   <draw:gradient draw:name="Gradient_20_2" draw:display-name="Gradient 2" draw:style="linear" draw:start-color="#000000" draw:end-color="#ffffff" draw:start-intensity="100%" draw:end-intensity="100%" draw:angle="0deg" draw:border="0%"/>

--- a/scripts/python/src/fodt/xml_filter_meta.py
+++ b/scripts/python/src/fodt/xml_filter_meta.py
@@ -28,7 +28,7 @@ class FilterAll:
 
     def filter_file(self, filename: Path) -> None:
         parser = xml.sax.make_parser()
-        handler = PassThroughFilterHandler()
+        handler = PassThroughFilterHandler(add_header=False)
         parser.setContentHandler(handler)
         parser.parse(filename)
         with open(filename, "w", encoding='utf8') as f:

--- a/scripts/python/src/fodt/xml_handlers.py
+++ b/scripts/python/src/fodt/xml_handlers.py
@@ -8,7 +8,8 @@ import xml.sax.saxutils
 from fodt.xml_helpers import XMLHelper
 
 class PassThroughFilterHandler(xml.sax.handler.ContentHandler):
-    def __init__(self) -> None:
+    def __init__(self, add_header=True) -> None:
+        self.add_header = add_header
         self.content = io.StringIO()
         self.start_tag_open = False  # For empty tags, do not close with />
 
@@ -31,7 +32,8 @@ class PassThroughFilterHandler(xml.sax.handler.ContentHandler):
         return self.content.getvalue()
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        if self.add_header:
+            self.content.write(XMLHelper.header)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if self.start_tag_open:


### PR DESCRIPTION
A bug was introduced in #230 and #231 such that the xml header tag was added to all meta files.

This PR removes the headers from the meta files (introduced in #231) and fixes the `fodt-xml-sax-filter-meta` script to work correctly (not adding the header to the meta files)

Thanks to @gdfldm for spotting the problem.