### PR TITLE
Fixed a bug in the fodt-set-keyword-status script

### DIFF
--- a/parts/appendices/A.fodt
+++ b/parts/appendices/A.fodt
@@ -6826,7 +6826,8 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table38.H21" office:value-type="string">
-       <text:p text:style-name="P2480"/>      </table:table-cell>
+       <text:p text:style-name="P2480"/>
+      </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table35.2">
       <table:table-cell table:style-name="Table35.A48" table:number-columns-spanned="7" office:value-type="string">
@@ -6838,8 +6839,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:covered-table-cell/>
-      <table:table-cell table:style-name="Table35.H9" office:value-type="string">
-       <text:p text:style-name="P2480"/>      </table:table-cell>
+      <table:table-cell table:style-name="Table47.H7" office:value-type="string">
+       <text:p text:style-name="P2480"></text:p>
+      </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table35.2">
       <table:table-cell table:style-name="Table35.A48" table:number-columns-spanned="7" office:value-type="string">
@@ -6852,7 +6854,8 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
       <table:covered-table-cell/>
       <table:table-cell table:style-name="Table40.H8" office:value-type="string">
-       <text:p text:style-name="P2480"/>      </table:table-cell>
+       <text:p text:style-name="P2480"/>
+      </table:table-cell>
      </table:table-row>
      <table:table-row table:style-name="Table35.2">
       <table:table-cell table:style-name="Table35.A48" table:number-columns-spanned="7" office:value-type="string">

--- a/scripts/python/src/fodt/add_keyword_status.py
+++ b/scripts/python/src/fodt/add_keyword_status.py
@@ -83,15 +83,16 @@ class AppendixKeywordHandler(xml.sax.handler.ContentHandler):
                 self.in_table_cell = False
             elif self.in_table_cell_style and name == "style:style":
                 self.in_table_cell_style = False
-        if self.in_table_cell_p and name == "text:p" and self.start_tag_open and self.opm_flow:
+        if self.in_table_cell_p and name == "text:p" and self.start_tag_open:
             self.content.write(">")
             self.start_tag_open = False
-            content = "OPM Flow"
             self.keyword_handled = True
             self.current_keyword = None
             self.in_table_cell_p = False
             self.found_table_cell = False
-            self.content.write(XMLHelper.escape(content))
+            if self.opm_flow:
+                content = "OPM Flow"
+                self.content.write(XMLHelper.escape(content))
         if self.start_tag_open:
             self.content.write("/>")
             self.start_tag_open = False
@@ -229,7 +230,7 @@ def set_keyword_status(
     try:
         color = KeywordStatus[color.upper()]
     except ValueError:
-        raise ValueError(f"Invalid status value: {status}.")
+        raise ValueError(f"Invalid color value: {color}.")
     logging.info(f"Updating parameters for keyword {keyword}:  Color: {color}, flow-specific keyword: {opm_flow}.")
     UpdateKeywordStatus(maindir, keyword, color, opm_flow).update()
 


### PR DESCRIPTION
For background see https://github.com/OPM/opm-reference-manual/pull/238#discussion_r1611595172.

A newline was accidentally gobbled up by the `fodt-set-keyword-status` script. Hopefully this change fixes the issue.