### PR TITLE
Add SUMMARY variables GKDI and GKDM 

### DIFF
--- a/parts/chapters/sections/11/2.fodt
+++ b/parts/chapters/sections/11/2.fodt
@@ -22987,7 +22987,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      </table:table-row>
      <table:table-row table:style-name="Table12.3">
       <table:table-cell table:style-name="Table12.A3" office:value-type="string">
-       <text:p text:style-name="P82">Volume</text:p>
+       <text:p text:style-name="P82">Moles</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table12.B3" office:value-type="string">
        <text:p text:style-name="P82">CO<text:span text:style-name="T106">2</text:span> Dissolved and immobile in the gas phase</text:p>
@@ -23016,7 +23016,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      </table:table-row>
      <table:table-row table:style-name="Table12.4">
       <table:table-cell table:style-name="Table12.A4" office:value-type="string">
-       <text:p text:style-name="P82">Volume</text:p>
+       <text:p text:style-name="P82">Moles</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table12.B3" office:value-type="string">
        <text:p text:style-name="P82">CO<text:span text:style-name="T106">2</text:span> Dissolved and mobile in the gas phase</text:p>
@@ -23045,7 +23045,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      </table:table-row>
      <table:table-row table:style-name="Table12.5">
       <table:table-cell table:style-name="Table12.A4" office:value-type="string">
-       <text:p text:style-name="P82">Volume</text:p>
+       <text:p text:style-name="P82">Moles</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table12.B3" office:value-type="string">
        <text:p text:style-name="P82">CO<text:span text:style-name="T106">2</text:span> Dissolved in the water phase</text:p>

--- a/parts/chapters/sections/11/2.fodt
+++ b/parts/chapters/sections/11/2.fodt
@@ -8262,9 +8262,6 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
   <style:style style:name="P386" style:family="paragraph" style:parent-style-name="Text_20_body">
    <style:text-properties officeooo:rsid="0fa39ca9" officeooo:paragraph-rsid="0fa56224"/>
   </style:style>
-  <style:style style:name="P387" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <style:text-properties officeooo:rsid="00582690" officeooo:paragraph-rsid="00582690"/>
-  </style:style>
   <style:style style:name="P388" style:family="paragraph" style:parent-style-name="_40_Example">
    <style:text-properties officeooo:paragraph-rsid="0fdf76c0"/>
   </style:style>
@@ -23043,6 +23040,64 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P81"/>
       </table:table-cell>
      </table:table-row>
+     <table:table-row table:style-name="Table12.3">
+      <table:table-cell table:style-name="Table12.A3" office:value-type="string">
+       <text:p text:style-name="P82">Moles</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.B3" office:value-type="string">
+       <text:p text:style-name="P82">CO<text:span text:style-name="T106">2</text:span> Dissolved and immobile in the gas phase (Non-wetting relative permeability equals zero)</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.A3" office:value-type="string">
+       <text:p text:style-name="P82">GKDI</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.A3" office:value-type="string">
+       <text:p text:style-name="P82">FGKDI</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.E3" office:value-type="string">
+       <text:p text:style-name="P81"/>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.E3" office:value-type="string">
+       <text:p text:style-name="P81"/>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.E3" office:value-type="string">
+       <text:p text:style-name="P81"/>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.A3" office:value-type="string">
+       <text:p text:style-name="P82">RGKDI</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.E3" office:value-type="string">
+       <text:p text:style-name="P81"/>
+      </table:table-cell>
+     </table:table-row>
+     <table:table-row table:style-name="Table12.4">
+      <table:table-cell table:style-name="Table12.A4" office:value-type="string">
+       <text:p text:style-name="P82">Moles</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.B3" office:value-type="string">
+       <text:p text:style-name="P82">CO<text:span text:style-name="T106">2</text:span> Dissolved and mobile in the gas phase (Non-wetting relative permeability greater than zero)</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.C4" office:value-type="string">
+       <text:p text:style-name="P82">GKDM</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.A3" office:value-type="string">
+       <text:p text:style-name="P82">FGKDM</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.E3" office:value-type="string">
+       <text:p text:style-name="P81"/>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.E3" office:value-type="string">
+       <text:p text:style-name="P81"/>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.E3" office:value-type="string">
+       <text:p text:style-name="P81"/>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.A3" office:value-type="string">
+       <text:p text:style-name="P82">RGKDM</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="Table12.E3" office:value-type="string">
+       <text:p text:style-name="P81"/>
+      </table:table-cell>
+     </table:table-row>
      <table:table-row table:style-name="Table12.5">
       <table:table-cell table:style-name="Table12.A4" office:value-type="string">
        <text:p text:style-name="P82">Moles</text:p>
@@ -23157,7 +23212,8 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     </table:table>
     <text:p text:style-name="P391">Table <text:sequence text:ref-name="refTable12" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">11.2.13</text:sequence>: CO2STORE Summary Variables</text:p>
     <text:p text:style-name="P379"/>
-    <text:p text:style-name="P387">Note that the WIPG and WIPL series of variables are OPM Flow specific variables.</text:p>
+    <text:p text:style-name="_40_TextBody">The 11th Society of Petroleum Engineers Comparative Solution Project (http://spe.org/csp) defines the “immobile free-phase CO<text:span text:style-name="T106">2</text:span>” as “CO<text:span text:style-name="T106">2</text:span> at saturations for which the non-wetting phase relative permeability equals zero”.</text:p>
+    <text:p text:style-name="_40_TextBody">Note that the WIPG and WIPL series of variables are OPM Flow specific variables.</text:p>
     <text:h text:style-name="P342" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc311682_2754225602"/>Option Specific Variables – Coal Bed Methane Model<text:bookmark-end text:name="__RefHeading___Toc311682_2754225602"/></text:h>
     <text:p text:style-name="P337">The Coal Bed Methane model is not supported by OPM Flow.</text:p>
     <text:h text:style-name="P353" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc311684_2754225602"/>Option Specific Variables – Conductive Faults Model<text:bookmark-end text:name="__RefHeading___Toc311684_2754225602"/></text:h>


### PR DESCRIPTION
Field and Region level summary vectors have been added when using the CO2STORE option based on this definition as follows ([#5281](https://github.com/OPM/opm-simulators/pull/5281), [#4010](https://github.com/OPM/opm-common/pull/4010)): Gas Moles in the Immobile Gas Phase (Non-wetting relative permeability equals zero), Gas Moles in the Mobile Gas Phase (Non-wetting relative permeability greater than zero), Gas Mass in the Immobile Gas Phase, and Gas Mass in the Mobile Gas Phase.

Depends on #270 