### PR TITLE
Fix spelling mistake in appendix A

### DIFF
--- a/parts/appendices/A.fodt
+++ b/parts/appendices/A.fodt
@@ -23423,7 +23423,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      </table:table-row>
      <table:table-row table:style-name="Table37.5">
       <table:table-cell table:style-name="Table37.A4" table:number-columns-spanned="7" office:value-type="string">
-       <text:p text:style-name="P1147"><text:a xlink:type="simple" xlink:href="#8.3.321.SWGFLET – Water-Gas LET Relative Permeability Functions |outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc548127_947687768">SGWFLET – Gas-Water LET Relative Permeability Functions</text:bookmark-ref></text:a></text:p>
+       <text:p text:style-name="P1147"><text:a xlink:type="simple" xlink:href="#8.3.321.SGWFLET – Gas-Water LET Relative Permeability Functions |outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc548127_947687768">SGWFLET – Gas-Water LET Relative Permeability Functions</text:bookmark-ref></text:a></text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>


### PR DESCRIPTION
For background see https://github.com/OPM/opm-reference-manual/pull/282

This fixes a spelling mistake in appendix A. This mistake seems to have  confused the add-keyword script such that it could add the keyword at the wrong position.