### PR TITLE
Minor edits #4

### DIFF
--- a/parts/chapters/subsections/10.3/DATUMR.fodt
+++ b/parts/chapters/subsections/10.3/DATUMR.fodt
@@ -4306,7 +4306,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P1588">Notes:</text:p>
        <text:list xml:id="list105917531259601" text:continue-list="list1467656974" text:style-name="L105">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P19289">The keyword is followed by FIPNUM values as defined on REGDIMS keyword in the RUNSPEC section.</text:p>
+         <text:p text:style-name="P19289">The keyword is followed by NTFIP values as defined on REGDIMS keyword in the RUNSPEC section.</text:p>
         </text:list-item>
         <text:list-item>
          <text:p text:style-name="P18995">The keyword is terminated by a “/”.</text:p>
@@ -4334,7 +4334,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:p text:style-name="P13386"><text:s text:c="9"/>4900.0</text:p>
     <text:p text:style-name="P13082"><text:s text:c="9"/>5000.0 <text:s text:c="37"/>/ DATUM DEPTH FOR REPORTING <text:s text:c="13"/><text:s text:c="77"/></text:p>
     <text:p text:style-name="P15101"/>
-    <text:p text:style-name="P15101">The above example defines the datum depth for three FIPNUM regions, for when FIPNUM has been set equal to three on the REGDIMS keyword in the RUNSPEC section.</text:p>
+    <text:p text:style-name="P15101">The above example defines the datum depth for three FIPNUM regions, for when NTFIP has been set equal to three on the REGDIMS keyword in the RUNSPEC section.</text:p>
     <text:p text:style-name="P15101"/>
     
    </text:section>

--- a/parts/chapters/subsections/10.3/DATUMRX.fodt
+++ b/parts/chapters/subsections/10.3/DATUMRX.fodt
@@ -4244,7 +4244,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      </table:table-row>
     </table:table>
     <text:h text:style-name="P18345" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc716355_3964674244"/>Description<text:bookmark-end text:name="__RefHeading___Toc716355_3964674244"/></text:h>
-    <text:p text:style-name="_40_TextBody">The DATUMRX keyword defines the datum depth for each fluid in-place family region defined by the FIP keyword. This allows for all grid block pressures and potentials to be calculated at a common depth within a given FIP region. The FIP keyword in the REGION sections allows one to define additional sets of fluid in-place regions to the standard FIPNUM keyword. For example, one could use FIPNUM to define the reservoir layers as fluid in-place regions and the FIP keyword to define he fluid in-place region for fault blocks.</text:p>
+    <text:p text:style-name="_40_TextBody">The DATUMRX keyword defines the datum depth for each fluid in-place family region defined by the FIP keyword. This allows for all grid block pressures and potentials to be calculated at a common depth within a given FIP region. The FIP keyword in the REGIONS section allows one to define additional sets of fluid in-place regions to the standard FIPNUM keyword. For example, one could use FIPNUM to define the reservoir layers as fluid in-place regions and the FIP keyword to define the fluid in-place region for fault blocks.</text:p>
     <table:table table:name="Table1047" table:style-name="Table1047">
      <table:table-column table:style-name="Table1047.A"/>
      <table:table-column table:style-name="Table1047.B"/>
@@ -4307,7 +4307,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       </table:table-cell>
       <table:table-cell table:style-name="Table1047.C2" table:number-columns-spanned="3" office:value-type="string">
        <text:p text:style-name="P4905">DATUMR is a vector of positive values that defines the datum depth for each fluid in-place family region. There must be one entry for each region in the FIP family name.</text:p>
-       <text:p text:style-name="P7763">A maximum of NTFIP, as declared by the REGDIMS keyword in the RUNSPEC, values may be entered for each FIPNAME entry.</text:p>
+       <text:p text:style-name="P7763">A maximum of NTFIP values, as declared by the REGDIMS keyword in the RUNSPEC section, may be entered for each FIPNAME entry.</text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>

--- a/parts/chapters/subsections/8.3/PVTG.fodt
+++ b/parts/chapters/subsections/8.3/PVTG.fodt
@@ -4602,7 +4602,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:p text:style-name="P13443"><text:s text:c="18"/>0 <text:s text:c="12"/>0.020430 <text:s text:c="5"/>0.01450 <text:s text:c="5"/>/</text:p>
     <text:p text:style-name="P13443"><text:s text:c="10"/> 60 <text:s text:c="4"/>0.000126 <text:s text:c="5"/>0.013280 <text:s text:c="5"/>0.01526 <text:s text:c="5"/></text:p>
     <text:p text:style-name="P13443"><text:s text:c="18"/>0 <text:s text:c="12"/>0.013250 <text:s text:c="5"/>0.01532 <text:s text:c="5"/>/</text:p>
-    <text:p text:style-name="P13443"><text:s text:c="9"/>  80 <text:s text:c="4"/>0.000135 <text:s text:c="5"/>0.009770 <text:s text:c="5"/>0.01660 <text:s text:c="5"/></text:p>
+    <text:p text:style-name="P13443"><text:s text:c="10"/> 80 <text:s text:c="4"/>0.000135 <text:s text:c="5"/>0.009770 <text:s text:c="5"/>0.01660 <text:s text:c="5"/></text:p>
     <text:p text:style-name="P13443"><text:s text:c="18"/>0 <text:s text:c="12"/>0.009730 <text:s text:c="5"/>0.01634 <text:s text:c="5"/>/</text:p>
     <text:p text:style-name="P13443"><text:s text:c="9"/> 100 <text:s text:c="4"/>0.000149 <text:s text:c="5"/>0.007730 <text:s text:c="5"/>0.01818 <text:s text:c="5"/></text:p>
     <text:p text:style-name="P13443"><text:s text:c="18"/>0 <text:s text:c="12"/>0.007690 <text:s text:c="5"/>0.01752 <text:s text:c="5"/>/</text:p>
@@ -4616,13 +4616,13 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:p text:style-name="P13443">-- <text:s text:c="6"/>PRES <text:s text:c="6"/>RV <text:s text:c="10"/>BG <text:s text:c="10"/>VISC <text:s text:c="56"/></text:p>
     <text:p text:style-name="P13443">-- <text:s text:c="6"/>BARSA<text:s text:c="4"/>SM^3/SM^3 <text:s text:c="4"/>RM^3/SM^3 <text:s text:c="6"/>CPOISE <text:s text:c="55"/></text:p>
     <text:p text:style-name="P13443">-- <text:s text:c="5"/>------ <text:s text:c="3"/>--------- <text:s text:c="3"/>------- <text:s text:c="6"/>------ <text:s text:c="47"/></text:p>
-    <text:p text:style-name="P13443"><text:s text:c="10"/> 20 <text:s text:c="4"/>0.000132 <text:s text:c="5"/>0.042340 <text:s text:c="5"/>0.01344 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P13443"><text:s text:c="10"/> 40 <text:s text:c="4"/>0.000124 <text:s text:c="5"/>0.020460 <text:s text:c="5"/>0.01420 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P13443"><text:s text:c="10"/> 60 <text:s text:c="4"/>0.000126 <text:s text:c="5"/>0.013280 <text:s text:c="5"/>0.01526 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P13443"><text:s text:c="9"/>  80 <text:s text:c="4"/>0.000135 <text:s text:c="5"/>0.009770 <text:s text:c="5"/>0.01660 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P13443"><text:s text:c="9"/> 100 <text:s text:c="4"/>0.000149 <text:s text:c="5"/>0.007730 <text:s text:c="5"/>0.01818 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P13443"><text:s text:c="9"/> 120 <text:s text:c="4"/>0.000163 <text:s text:c="5"/>0.006426 <text:s text:c="5"/>0.01994 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P13443"><text:s text:c="9"/> 140 <text:s text:c="4"/>0.000191 <text:s text:c="5"/>0.005541 <text:s text:c="5"/>0.02181 <text:s text:c="5"/></text:p>
+    <text:p text:style-name="P13443"><text:s text:c="10"/> 20 <text:s text:c="4"/>0.000132 <text:s text:c="5"/>0.042340 <text:s text:c="5"/>0.01344 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P13443"><text:s text:c="10"/> 40 <text:s text:c="4"/>0.000124 <text:s text:c="5"/>0.020460 <text:s text:c="5"/>0.01420 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P13443"><text:s text:c="10"/> 60 <text:s text:c="4"/>0.000126 <text:s text:c="5"/>0.013280 <text:s text:c="5"/>0.01526 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P13443"><text:s text:c="10"/> 80 <text:s text:c="4"/>0.000135 <text:s text:c="5"/>0.009770 <text:s text:c="5"/>0.01660 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P13443"><text:s text:c="9"/> 100 <text:s text:c="4"/>0.000149 <text:s text:c="5"/>0.007730 <text:s text:c="5"/>0.01818 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P13443"><text:s text:c="9"/> 120 <text:s text:c="4"/>0.000163 <text:s text:c="5"/>0.006426 <text:s text:c="5"/>0.01994 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P13443"><text:s text:c="9"/> 140 <text:s text:c="4"/>0.000191 <text:s text:c="5"/>0.005541 <text:s text:c="5"/>0.02181 <text:s text:c="5"/>/</text:p>
     <text:p text:style-name="P13443"><text:s text:c="9"/> 160 <text:s text:c="4"/>0.000225 <text:s text:c="5"/>0.004919 <text:s text:c="5"/>0.02370 <text:s text:c="5"/></text:p>
     <text:p text:style-name="P13443"><text:s text:c="18"/>0 <text:s text:c="12"/>0.004952 <text:s text:c="5"/>0.02163 <text:s text:c="5"/>/ </text:p>
     <text:p text:style-name="P13444"><text:s text:c="14"/><text:s text:c="45"/>/ TABLE NO. 2</text:p>
@@ -4642,7 +4642,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:p text:style-name="P13448"><text:s text:c="18"/>0 <text:s text:c="12"/>0.020430 <text:s text:c="5"/>0.01450 <text:s text:c="5"/>/</text:p>
     <text:p text:style-name="P13448"><text:s text:c="10"/> 60 <text:s text:c="4"/>0.000126 <text:s text:c="5"/>0.013280 <text:s text:c="5"/>0.01526 <text:s text:c="5"/></text:p>
     <text:p text:style-name="P13448"><text:s text:c="18"/>0 <text:s text:c="12"/>0.013250 <text:s text:c="5"/>0.01532 <text:s text:c="5"/>/</text:p>
-    <text:p text:style-name="P13448"><text:s text:c="9"/>  80 <text:s text:c="4"/>0.000135 <text:s text:c="5"/>0.009770 <text:s text:c="5"/>0.01660 <text:s text:c="5"/></text:p>
+    <text:p text:style-name="P13448"><text:s text:c="10"/> 80 <text:s text:c="4"/>0.000135 <text:s text:c="5"/>0.009770 <text:s text:c="5"/>0.01660 <text:s text:c="5"/></text:p>
     <text:p text:style-name="P13448"><text:s text:c="18"/>0 <text:s text:c="12"/>0.009730 <text:s text:c="5"/>0.01634 <text:s text:c="5"/>/</text:p>
     <text:p text:style-name="P13448"><text:s text:c="9"/> 100 <text:s text:c="4"/>0.000149 <text:s text:c="5"/>0.007730 <text:s text:c="5"/>0.01818 <text:s text:c="5"/></text:p>
     <text:p text:style-name="P13448"><text:s text:c="18"/>0 <text:s text:c="12"/>0.007690 <text:s text:c="5"/>0.01752 <text:s text:c="5"/>/</text:p>
@@ -4657,13 +4657,13 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:p text:style-name="P13448">-- <text:s text:c="6"/>PRES <text:s text:c="6"/>RV <text:s text:c="10"/>BG <text:s text:c="10"/>VISC <text:s text:c="56"/></text:p>
     <text:p text:style-name="P13448">-- <text:s text:c="6"/>BARSA<text:s text:c="4"/>SM^3/SM^3 <text:s text:c="4"/>RM^3/SM^3 <text:s text:c="6"/>CPOISE <text:s text:c="55"/></text:p>
     <text:p text:style-name="P13448">-- <text:s text:c="5"/>------ <text:s text:c="3"/>--------- <text:s text:c="3"/>------- <text:s text:c="6"/>------ <text:s text:c="47"/></text:p>
-    <text:p text:style-name="P13448"><text:s text:c="10"/> 20 <text:s text:c="4"/>0.000132 <text:s text:c="5"/>0.042340 <text:s text:c="5"/>0.01344 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P13448"><text:s text:c="10"/> 40 <text:s text:c="4"/>0.000124 <text:s text:c="5"/>0.020460 <text:s text:c="5"/>0.01420 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P13448"><text:s text:c="10"/> 60 <text:s text:c="4"/>0.000126 <text:s text:c="5"/>0.013280 <text:s text:c="5"/>0.01526 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P13448"><text:s text:c="9"/>  80 <text:s text:c="4"/>0.000135 <text:s text:c="5"/>0.009770 <text:s text:c="5"/>0.01660 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P13448"><text:s text:c="9"/> 100 <text:s text:c="4"/>0.000149 <text:s text:c="5"/>0.007730 <text:s text:c="5"/>0.01818 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P13448"><text:s text:c="9"/> 120 <text:s text:c="4"/>0.000163 <text:s text:c="5"/>0.006426 <text:s text:c="5"/>0.01994 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P13448"><text:s text:c="9"/> 140 <text:s text:c="4"/>0.000191 <text:s text:c="5"/>0.005541 <text:s text:c="5"/>0.02181 <text:s text:c="5"/></text:p>
+    <text:p text:style-name="P13448"><text:s text:c="10"/> 20 <text:s text:c="4"/>0.000132 <text:s text:c="5"/>0.042340 <text:s text:c="5"/>0.01344 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P13448"><text:s text:c="10"/> 40 <text:s text:c="4"/>0.000124 <text:s text:c="5"/>0.020460 <text:s text:c="5"/>0.01420 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P13448"><text:s text:c="10"/> 60 <text:s text:c="4"/>0.000126 <text:s text:c="5"/>0.013280 <text:s text:c="5"/>0.01526 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P13448"><text:s text:c="10"/> 80 <text:s text:c="4"/>0.000135 <text:s text:c="5"/>0.009770 <text:s text:c="5"/>0.01660 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P13448"><text:s text:c="9"/> 100 <text:s text:c="4"/>0.000149 <text:s text:c="5"/>0.007730 <text:s text:c="5"/>0.01818 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P13448"><text:s text:c="9"/> 120 <text:s text:c="4"/>0.000163 <text:s text:c="5"/>0.006426 <text:s text:c="5"/>0.01994 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P13448"><text:s text:c="9"/> 140 <text:s text:c="4"/>0.000191 <text:s text:c="5"/>0.005541 <text:s text:c="5"/>0.02181 <text:s text:c="5"/>/</text:p>
     <text:p text:style-name="P13448"><text:s text:c="9"/> 160 <text:s text:c="4"/>0.000225 <text:s text:c="5"/>0.004919 <text:s text:c="5"/>0.02370 <text:s text:c="5"/></text:p>
     <text:p text:style-name="_40_Example"><text:s text:c="18"/>0 <text:s text:c="12"/>0.004952 <text:s text:c="5"/>0.02163 <text:s text:c="5"/>/ </text:p>
     <text:p text:style-name="_40_Example"><text:s text:c="14"/><text:s text:c="45"/>/ TABLE NO. 3</text:p>

--- a/parts/chapters/subsections/8.3/PVTGW.fodt
+++ b/parts/chapters/subsections/8.3/PVTGW.fodt
@@ -4766,7 +4766,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:p text:style-name="P48">-- <text:s text:c="85"/></text:p>
     <text:p text:style-name="P48">PVTGW</text:p>
     <text:p text:style-name="P48">-- <text:s text:c="6"/>PRES <text:s text:c="6"/>RW <text:s text:c="10"/>BG <text:s text:c="10"/>VISC <text:s text:c="56"/></text:p>
-    <text:p text:style-name="P13442">-- <text:s text:c="6"/>PSIA <text:s text:c="4"/>SM^3/SM^3 <text:s text:c="4"/>RM^3/SM^3 <text:s text:c="6"/>CPOISE <text:s text:c="55"/></text:p>
+    <text:p text:style-name="P48">-- <text:s text:c="6"/>PSIA <text:s text:c="4"/>SM^3/SM^3 <text:s text:c="4"/>RM^3/SM^3 <text:s text:c="6"/>CPOISE <text:s text:c="55"/></text:p>
     <text:p text:style-name="P48">-- <text:s text:c="5"/>------ <text:s text:c="3"/>--------- <text:s text:c="3"/>------- <text:s text:c="6"/>------ <text:s text:c="47"/></text:p>
     <text:p text:style-name="P49"><text:s text:c="10"/>300 <text:s text:c="4"/>0.000479 <text:s text:c="5"/>0.042340 <text:s text:c="5"/>0.01344 <text:s text:c="5"/></text:p>
     <text:p text:style-name="P49"><text:s text:c="18"/>0 <text:s text:c="12"/>0.042310 <text:s text:c="5"/>0.01389 <text:s text:c="5"/>/</text:p>
@@ -4786,15 +4786,15 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:p text:style-name="P49"><text:s text:c="18"/>0 <text:s text:c="12"/>0.004952 <text:s text:c="5"/>0.02163 <text:s text:c="5"/>/</text:p>
     <text:p text:style-name="P49"><text:s text:c="59"/>/ TABLE NO. 1 </text:p>
     <text:p text:style-name="P48">-- <text:s text:c="6"/>PRES <text:s text:c="6"/>RW <text:s text:c="10"/>BG <text:s text:c="10"/>VISC <text:s text:c="56"/></text:p>
-    <text:p text:style-name="P13442">-- <text:s text:c="6"/>PSIA <text:s text:c="4"/>SM^3/SM^3 <text:s text:c="4"/>RM^3/SM^3 <text:s text:c="6"/>CPOISE <text:s text:c="55"/></text:p>
+    <text:p text:style-name="P48">-- <text:s text:c="6"/>PSIA <text:s text:c="4"/>SM^3/SM^3 <text:s text:c="4"/>RM^3/SM^3 <text:s text:c="6"/>CPOISE <text:s text:c="55"/></text:p>
     <text:p text:style-name="P48">-- <text:s text:c="5"/>------ <text:s text:c="3"/>--------- <text:s text:c="3"/>------- <text:s text:c="6"/>------ <text:s text:c="47"/></text:p>
-    <text:p text:style-name="P49"><text:s text:c="10"/>300 <text:s text:c="4"/>0.000479 <text:s text:c="5"/>0.042340 <text:s text:c="5"/>0.01344 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P49"><text:s text:c="10"/>600 <text:s text:c="4"/>0.000469 <text:s text:c="5"/>0.020460 <text:s text:c="5"/>0.01420 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P49"><text:s text:c="10"/>900 <text:s text:c="4"/>0.000403 <text:s text:c="5"/>0.013280 <text:s text:c="5"/>0.01526 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P49"><text:s text:c="9"/>1200 <text:s text:c="4"/>0.000354 <text:s text:c="5"/>0.009770 <text:s text:c="5"/>0.01660 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P49"><text:s text:c="9"/>1500 <text:s text:c="4"/>0.000272 <text:s text:c="5"/>0.007730 <text:s text:c="5"/>0.01818 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P49"><text:s text:c="9"/>1800 <text:s text:c="4"/>0.000225 <text:s text:c="5"/>0.006426 <text:s text:c="5"/>0.01994 <text:s text:c="5"/></text:p>
-    <text:p text:style-name="P49"><text:s text:c="9"/>2100 <text:s text:c="4"/>0.000191 <text:s text:c="5"/>0.005541 <text:s text:c="5"/>0.02181 <text:s text:c="5"/></text:p>
+    <text:p text:style-name="P49"><text:s text:c="10"/>300 <text:s text:c="4"/>0.000479 <text:s text:c="5"/>0.042340 <text:s text:c="5"/>0.01344 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P49"><text:s text:c="10"/>600 <text:s text:c="4"/>0.000469 <text:s text:c="5"/>0.020460 <text:s text:c="5"/>0.01420 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P49"><text:s text:c="10"/>900 <text:s text:c="4"/>0.000403 <text:s text:c="5"/>0.013280 <text:s text:c="5"/>0.01526 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P49"><text:s text:c="9"/>1200 <text:s text:c="4"/>0.000354 <text:s text:c="5"/>0.009770 <text:s text:c="5"/>0.01660 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P49"><text:s text:c="9"/>1500 <text:s text:c="4"/>0.000272 <text:s text:c="5"/>0.007730 <text:s text:c="5"/>0.01818 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P49"><text:s text:c="9"/>1800 <text:s text:c="4"/>0.000225 <text:s text:c="5"/>0.006426 <text:s text:c="5"/>0.01994 <text:s text:c="5"/>/</text:p>
+    <text:p text:style-name="P49"><text:s text:c="9"/>2100 <text:s text:c="4"/>0.000191 <text:s text:c="5"/>0.005541 <text:s text:c="5"/>0.02181 <text:s text:c="5"/>/</text:p>
     <text:p text:style-name="P49"><text:s text:c="9"/>2400 <text:s text:c="4"/>0.000163 <text:s text:c="5"/>0.004919 <text:s text:c="5"/>0.02370 <text:s text:c="5"/>/</text:p>
     <text:p text:style-name="P49"><text:s text:c="14"/><text:s text:c="45"/>/ TABLE NO. 2</text:p>
     <text:p text:style-name="P51"/>

--- a/parts/chapters/subsections/8.3/PVTGWO.fodt
+++ b/parts/chapters/subsections/8.3/PVTGWO.fodt
@@ -4836,13 +4836,13 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:p text:style-name="P52">-- <text:s text:c="6"/>PRES <text:s text:c="4"/>RW <text:s text:c="8"/>RV <text:s text:c="7"/>BG <text:s text:c="7"/>VISC <text:s text:c="53"/></text:p>
     <text:p text:style-name="P52">-- <text:s text:c="6"/>PSIA <text:s text:c="2"/>STB/MSCF <text:s text:c="2"/>STB/MSCF <text:s text:c="2"/>RB/MSCF <text:s text:c="3"/>CPOISE <text:s text:c="52"/></text:p>
     <text:p text:style-name="P52">-- <text:s text:c="5"/>------ <text:s/>-------- <text:s text:c="2"/>--------- <text:s/>------- <text:s text:c="3"/>------ <text:s text:c="44"/></text:p>
-    <text:p text:style-name="P53"><text:s text:c="10"/>300 <text:s text:c="2"/>0.000479 <text:s text:c="2"/>0.000132 <text:s text:c="2"/>0.042340 <text:s text:c="2"/>0.01344 <text:s text:c="2"/></text:p>
-    <text:p text:style-name="P53"><text:s text:c="10"/>600 <text:s text:c="2"/>0.000469 <text:s text:c="2"/>0.000124 <text:s text:c="2"/>0.020460 <text:s text:c="2"/>0.01420 <text:s text:c="2"/></text:p>
-    <text:p text:style-name="P53"><text:s text:c="10"/>900 <text:s text:c="2"/>0.000403 <text:s text:c="2"/>0.000126 <text:s text:c="2"/>0.013280 <text:s text:c="2"/>0.01526 <text:s text:c="2"/></text:p>
-    <text:p text:style-name="P53"><text:s text:c="9"/>1200 <text:s text:c="2"/>0.000354 <text:s text:c="2"/>0.000135 <text:s text:c="2"/>0.009770 <text:s text:c="2"/>0.01660 <text:s text:c="2"/></text:p>
-    <text:p text:style-name="P53"><text:s text:c="9"/>1500 <text:s text:c="2"/>0.000272 <text:s text:c="2"/>0.000149 <text:s text:c="2"/>0.007730 <text:s text:c="2"/>0.01818 <text:s text:c="2"/></text:p>
-    <text:p text:style-name="P53"><text:s text:c="9"/>1800 <text:s text:c="2"/>0.000225 <text:s text:c="2"/>0.000163 <text:s text:c="2"/>0.006426 <text:s text:c="2"/>0.01994 <text:s text:c="2"/></text:p>
-    <text:p text:style-name="P53"><text:s text:c="9"/>2100 <text:s text:c="2"/>0.000191 <text:s text:c="2"/>0.000191 <text:s text:c="2"/>0.005541 <text:s text:c="2"/>0.02181 <text:s text:c="2"/></text:p>
+    <text:p text:style-name="P53"><text:s text:c="10"/>300 <text:s text:c="2"/>0.000479 <text:s text:c="2"/>0.000132 <text:s text:c="2"/>0.042340 <text:s text:c="2"/>0.01344 <text:s text:c="2"/>/</text:p>
+    <text:p text:style-name="P53"><text:s text:c="10"/>600 <text:s text:c="2"/>0.000469 <text:s text:c="2"/>0.000124 <text:s text:c="2"/>0.020460 <text:s text:c="2"/>0.01420 <text:s text:c="2"/>/</text:p>
+    <text:p text:style-name="P53"><text:s text:c="10"/>900 <text:s text:c="2"/>0.000403 <text:s text:c="2"/>0.000126 <text:s text:c="2"/>0.013280 <text:s text:c="2"/>0.01526 <text:s text:c="2"/>/</text:p>
+    <text:p text:style-name="P53"><text:s text:c="9"/>1200 <text:s text:c="2"/>0.000354 <text:s text:c="2"/>0.000135 <text:s text:c="2"/>0.009770 <text:s text:c="2"/>0.01660 <text:s text:c="2"/>/</text:p>
+    <text:p text:style-name="P53"><text:s text:c="9"/>1500 <text:s text:c="2"/>0.000272 <text:s text:c="2"/>0.000149 <text:s text:c="2"/>0.007730 <text:s text:c="2"/>0.01818 <text:s text:c="2"/>/</text:p>
+    <text:p text:style-name="P53"><text:s text:c="9"/>1800 <text:s text:c="2"/>0.000225 <text:s text:c="2"/>0.000163 <text:s text:c="2"/>0.006426 <text:s text:c="2"/>0.01994 <text:s text:c="2"/>/</text:p>
+    <text:p text:style-name="P53"><text:s text:c="9"/>2100 <text:s text:c="2"/>0.000191 <text:s text:c="2"/>0.000191 <text:s text:c="2"/>0.005541 <text:s text:c="2"/>0.02181 <text:s text:c="2"/>/</text:p>
     <text:p text:style-name="P53"><text:s text:c="9"/>2400 <text:s text:c="2"/>0.000163 <text:s text:c="2"/>0.000225 <text:s text:c="2"/>0.004919 <text:s text:c="2"/>0.02370 <text:s text:c="2"/>/</text:p>
     <text:p text:style-name="P53"><text:s text:c="14"/><text:s text:c="45"/>/ TABLE NO. 2</text:p>
     <text:p text:style-name="P55"/>


### PR DESCRIPTION
Corrected minor typos in new supported keywords for 2024.04. Added missing terminating slashes for sub-table records of second table in examples for PVTG series of keywords.