### PR TITLE
Repair DISPERSE keyword

### DIFF
--- a/parts/appendices/A.fodt
+++ b/parts/appendices/A.fodt
@@ -9145,7 +9145,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      </table:table-row>
      <table:table-row table:style-name="Table40.4">
       <table:table-cell table:style-name="Table40.A4" table:number-columns-spanned="7" office:value-type="string">
-       <text:p text:style-name="_40_Table_20_Contents"><text:a xlink:type="simple" xlink:href="#8.3.25.DISPERSE– Define Dispersion Tables|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc184339_1772380413">DISPERSE– Define Dispersion Tables</text:bookmark-ref></text:a></text:p>
+       <text:p text:style-name="_40_Table_20_Contents"><text:a xlink:type="simple" xlink:href="#8.3.25.DISPERSE – Define Dispersion Tables|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc184339_1772380413">DISPERSE – Define Dispersion Tables</text:bookmark-ref></text:a></text:p>
       </table:table-cell>
       <table:covered-table-cell/>
       <table:covered-table-cell/>

--- a/parts/chapters/subsections/8.3/DISPERSE.fodt
+++ b/parts/chapters/subsections/8.3/DISPERSE.fodt
@@ -4058,9 +4058,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:user-field-decl office:value-type="string" office:string-value="" text:name="SEQ CHAPTER \h   1"/>
    </text:user-field-decls>
    <text:p text:style-name="P18776"/>
-   <text:section text:style-name="Sect1" text:name="DISPERSE–">
+   <text:section text:style-name="Sect1" text:name="DISPERSE">
 
-<text:h text:style-name="P17663" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc184339_1772380413"/>DISPERSE– Define Dispersion Tables<text:bookmark-end text:name="__RefHeading___Toc184339_1772380413"/></text:h>
+<text:h text:style-name="P17663" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc184339_1772380413"/>DISPERSE – Define Dispersion Tables<text:bookmark-end text:name="__RefHeading___Toc184339_1772380413"/></text:h>
     <table:table table:name="Table1075" table:style-name="Table1075">
      <table:table-column table:style-name="Table1075.A" table:number-columns-repeated="4"/>
      <table:table-column table:style-name="Table1075.E"/>


### PR DESCRIPTION
Links to the DISPERSE keyword description seemed to be broken. This seems to be due to there being no space before the dash in the title of the page i.e. "DISPERSE- etc" not "DISPERSE - etc".