### PR TITLE
Remove references to tables in MESSAGES

### DIFF
--- a/parts/chapters/subsections/10.3/MESSAGES.fodt
+++ b/parts/chapters/subsections/10.3/MESSAGES.fodt
@@ -3999,11 +3999,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </text:user-field-decls>
    <text:p text:style-name="P18776"/>
    <text:section text:style-name="Sect1" text:name="MESSAGES">
-
-<text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249015"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249015"/></text:h>
-    <text:p text:style-name="P12343"><text:span text:style-name="T1">The </text:span>MESSAGES <text:span text:style-name="T1">keyword defines the </text:span>print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the <text:s text:c="2"/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in <text:span text:style-name="T1">severity </text:span>from informative all the way to programming errors, as outlined in <text:sequence-ref text:reference-format="category-and-value" text:ref-name="refTable15">Table 4.5</text:sequence-ref>.</text:p>
+    <text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249015"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249015"/></text:h>
+    <text:p text:style-name="P12343">The MESSAGES keyword defines the print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the<text:s/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in severity from informative all the way to programming errors.</text:p>
     <text:p text:style-name="P12344">S<text:span text:style-name="T1">ee </text:span><text:a xlink:type="simple" xlink:href="#3.1.7.MESSAGES – Defines Message Print Limits and Stop Limits|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc61634_2479612490">MESSAGES – Define Message Print Limits and Stop Limits</text:bookmark-ref></text:span></text:a><text:span text:style-name="T1"><text:s/>in the GLOBAL section for a full description.</text:span></text:p>
-    
    </text:section>
   </office:text>
  </office:body>

--- a/parts/chapters/subsections/11.3/MESSAGES.fodt
+++ b/parts/chapters/subsections/11.3/MESSAGES.fodt
@@ -3999,11 +3999,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </text:user-field-decls>
    <text:p text:style-name="P18776"/>
    <text:section text:style-name="Sect1" text:name="MESSAGES">
-
-<text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249016"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249016"/></text:h>
-    <text:p text:style-name="P12343"><text:span text:style-name="T1">The </text:span>MESSAGES <text:span text:style-name="T1">keyword defines the </text:span>print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the <text:s text:c="2"/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in <text:span text:style-name="T1">severity </text:span>from informative all the way to programming errors, as outlined in <text:sequence-ref text:reference-format="category-and-value" text:ref-name="refTable15">Table 4.5</text:sequence-ref>.</text:p>
+    <text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249016"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249016"/></text:h>
+    <text:p text:style-name="P12343">The MESSAGES keyword defines the print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the<text:s/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in severity from informative all the way to programming errors.</text:p>
     <text:p text:style-name="P12344">S<text:span text:style-name="T1">ee </text:span><text:a xlink:type="simple" xlink:href="#3.1.7.MESSAGES – Defines Message Print Limits and Stop Limits|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc61634_2479612490">MESSAGES – Define Message Print Limits and Stop Limits</text:bookmark-ref></text:span></text:a><text:span text:style-name="T1"><text:s/>in the GLOBAL section for a full description.</text:span></text:p>
-    
    </text:section>
   </office:text>
  </office:body>

--- a/parts/chapters/subsections/12.3/MESSAGES.fodt
+++ b/parts/chapters/subsections/12.3/MESSAGES.fodt
@@ -3999,13 +3999,11 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </text:user-field-decls>
    <text:p text:style-name="P18776"/>
    <text:section text:style-name="Sect1" text:name="MESSAGES">
-
-<text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249017"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249017"/></text:h>
-    <text:p text:style-name="P12343"><text:span text:style-name="T1">The </text:span>MESSAGES <text:span text:style-name="T1">keyword defines the </text:span>print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the <text:s text:c="2"/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in <text:span text:style-name="T1">severity </text:span>from informative all the way to programming errors, as outlined in <text:sequence-ref text:reference-format="category-and-value" text:ref-name="refTable15">Table 4.5</text:sequence-ref>.</text:p>
+    <text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249017"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249017"/></text:h>
+    <text:p text:style-name="P12343">The MESSAGES keyword defines the print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the<text:s/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in severity from informative all the way to programming errors.</text:p>
     <text:p text:style-name="P12344">See <text:a xlink:type="simple" xlink:href="#3.1.7.MESSAGES – Defines Message Print Limits and Stop Limits|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc61634_2479612490">MESSAGES – Define Message Print Limits and Stop Limits</text:bookmark-ref></text:a><text:s/>in the GLOBAL section for a full description.</text:p>
     <text:p text:style-name="_40_TextBody"/>
     <text:p text:style-name="_40_TextBody"/>
-    
    </text:section>
   </office:text>
  </office:body>

--- a/parts/chapters/subsections/4.3/MESSAGES.fodt
+++ b/parts/chapters/subsections/4.3/MESSAGES.fodt
@@ -4262,7 +4262,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      </table:table-row>
     </table:table>
     <text:h text:style-name="Heading_20_4" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc32167_370116838818"/>Description<text:bookmark-end text:name="__RefHeading___Toc32167_370116838818"/></text:h>
-    <text:p text:style-name="_40_TextBody"><text:span text:style-name="T1">The </text:span>MESSAGES <text:span text:style-name="T1">keyword defines the </text:span>print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the <text:s text:c="2"/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in <text:span text:style-name="T1">severity </text:span>from informative all the way to programming errors, as outlined in <text:sequence-ref text:reference-format="category-and-value" text:ref-name="refTable15">Table 4.5</text:sequence-ref>.</text:p>
+    <text:p text:style-name="_40_TextBody"><text:span text:style-name="T1">The </text:span>MESSAGES <text:span text:style-name="T1">keyword defines the </text:span>print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the <text:s text:c="2"/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in <text:span text:style-name="T1">severity </text:span>from informative all the way to programming errors, as outlined in <text:sequence-ref text:reference-format="category-and-value" text:ref-name="REF_TABLE_MESSAGES_KEYWORD__CRIPTION_4_3">Table 4.5</text:sequence-ref>.</text:p>
     <table:table table:name="Table290" table:style-name="Table290">
      <table:table-column table:style-name="Table290.A"/>
      <table:table-column table:style-name="Table290.B"/>
@@ -4506,7 +4506,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       <table:covered-table-cell/>
      </table:table-row>
     </table:table>
-    <text:p text:style-name="P14560">Table <text:sequence text:ref-name="refTable15" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">4.5</text:sequence>: MESSAGES Keyword Description</text:p>
+    <text:p text:style-name="P14560">Table <text:sequence text:ref-name="REF_TABLE_MESSAGES_KEYWORD__CRIPTION_4_3" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">4.5</text:sequence>: MESSAGES Keyword Description</text:p>
     <text:h text:style-name="Heading_20_4" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc32169_370116838818"/>Example<text:bookmark-end text:name="__RefHeading___Toc32169_370116838818"/></text:h>
     <text:p text:style-name="P14323">--</text:p>
     <text:p text:style-name="P12904">-- <text:s text:c="6"/>MESS <text:s/>COMMT WARN <text:s/>PROBL ERROR BUG <text:s text:c="2"/>MESS COMMT WARN <text:s/>PROBL ERROR BUG <text:s text:c="5"/></text:p>

--- a/parts/chapters/subsections/5.3/MESSAGES.fodt
+++ b/parts/chapters/subsections/5.3/MESSAGES.fodt
@@ -2605,12 +2605,6 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
   <style:style style:name="P2793" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0.203cm" fo:text-align="center" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
   </style:style>
-  <style:style style:name="P12343" style:family="paragraph" style:parent-style-name="_40_TextBody">
-   <style:text-properties officeooo:paragraph-rsid="147e6f1e"/>
-  </style:style>
-  <style:style style:name="P12344" style:family="paragraph" style:parent-style-name="_40_TextBody">
-   <style:text-properties officeooo:rsid="147e6f1e" officeooo:paragraph-rsid="147e6f1e"/>
-  </style:style>
   <style:style style:name="P17562" style:family="paragraph" style:parent-style-name="Heading_20_3">
    <style:text-properties fo:language="en" fo:country="US" officeooo:paragraph-rsid="147e6f1e"/>
   </style:style>
@@ -3999,11 +3993,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </text:user-field-decls>
    <text:p text:style-name="P18776"/>
    <text:section text:style-name="Sect1" text:name="MESSAGES">
-
-<text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_24796124901"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_24796124901"/></text:h>
-    <text:p text:style-name="P12343"><text:span text:style-name="T1">The </text:span>MESSAGES <text:span text:style-name="T1">keyword defines the </text:span>print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the <text:s text:c="2"/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in <text:span text:style-name="T1">severity </text:span>from informative all the way to programming errors, as outlined in <text:sequence-ref text:reference-format="category-and-value" text:ref-name="refTable15">Table 4.5</text:sequence-ref>.</text:p>
-    <text:p text:style-name="P12344">S<text:span text:style-name="T1">ee </text:span><text:a xlink:type="simple" xlink:href="#3.1.7.MESSAGES – Defines Message Print Limits and Stop Limits|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc61634_2479612490">MESSAGES – Define Message Print Limits and Stop Limits</text:bookmark-ref></text:span></text:a><text:span text:style-name="T1"><text:s/>in the GLOBAL section for a full description.</text:span></text:p>
-    
+    <text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_24796124901"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_24796124901"/></text:h>
+    <text:p text:style-name="_40_TextBody">The MESSAGES keyword defines the print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the<text:s/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in severity from informative all the way to programming errors.</text:p>
+    <text:p text:style-name="_40_TextBody">See <text:a xlink:type="simple" xlink:href="#3.1.7.MESSAGES – Defines Message Print Limits and Stop Limits|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc61634_2479612490">MESSAGES – Define Message Print Limits and Stop Limits</text:bookmark-ref></text:a><text:s/>in the GLOBAL section for a full description.</text:p>
    </text:section>
   </office:text>
  </office:body>

--- a/parts/chapters/subsections/6.3/MESSAGES.fodt
+++ b/parts/chapters/subsections/6.3/MESSAGES.fodt
@@ -3999,11 +3999,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </text:user-field-decls>
    <text:p text:style-name="P18776"/>
    <text:section text:style-name="Sect1" text:name="MESSAGES">
-
-<text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249011"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249011"/></text:h>
-    <text:p text:style-name="P12343"><text:span text:style-name="T1">The </text:span>MESSAGES <text:span text:style-name="T1">keyword defines the </text:span>print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the <text:s text:c="2"/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in <text:span text:style-name="T1">severity </text:span>from informative all the way to programming errors, as outlined in <text:sequence-ref text:reference-format="category-and-value" text:ref-name="refTable15">Table 4.5</text:sequence-ref>.</text:p>
+    <text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249011"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249011"/></text:h>
+    <text:p text:style-name="P12343">The MESSAGES keyword defines the print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the<text:s/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in severity from informative all the way to programming errors.</text:p>
     <text:p text:style-name="P11641">See <text:a xlink:type="simple" xlink:href="#3.1.7.MESSAGES – Defines Message Print Limits and Stop Limits|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc61634_2479612490">MESSAGES – Define Message Print Limits and Stop Limits</text:bookmark-ref></text:a><text:s/>in the GLOBAL section for a full description.</text:p>
-    
    </text:section>
   </office:text>
  </office:body>

--- a/parts/chapters/subsections/7.3/MESSAGES.fodt
+++ b/parts/chapters/subsections/7.3/MESSAGES.fodt
@@ -3999,12 +3999,10 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </text:user-field-decls>
    <text:p text:style-name="P18776"/>
    <text:section text:style-name="Sect1" text:name="MESSAGES">
-
-<text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249012"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249012"/></text:h>
-    <text:p text:style-name="P12343"><text:span text:style-name="T1">The </text:span>MESSAGES <text:span text:style-name="T1">keyword defines the </text:span>print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the <text:s text:c="2"/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in <text:span text:style-name="T1">severity </text:span>from informative all the way to programming errors, as outlined in <text:sequence-ref text:reference-format="category-and-value" text:ref-name="refTable15">Table 4.5</text:sequence-ref>.</text:p>
+    <text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249012"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249012"/></text:h>
+    <text:p text:style-name="P12343">The MESSAGES keyword defines the print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the<text:s/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in severity from informative all the way to programming errors.</text:p>
     <text:p text:style-name="P12344"><text:soft-page-break/>See <text:a xlink:type="simple" xlink:href="#3.1.7.MESSAGES – Defines Message Print Limits and Stop Limits|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc61634_2479612490">MESSAGES – Define Message Print Limits and Stop Limits</text:bookmark-ref></text:a><text:s/>in the GLOBAL section for a full description.</text:p>
     <text:p text:style-name="P12344"/>
-    
    </text:section>
   </office:text>
  </office:body>

--- a/parts/chapters/subsections/8.3/MESSAGES.fodt
+++ b/parts/chapters/subsections/8.3/MESSAGES.fodt
@@ -3996,11 +3996,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </text:user-field-decls>
    <text:p text:style-name="P18776"/>
    <text:section text:style-name="Sect1" text:name="MESSAGES">
-
-<text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249013"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249013"/></text:h>
-    <text:p text:style-name="P12343"><text:span text:style-name="T1">The </text:span>MESSAGES <text:span text:style-name="T1">keyword defines the </text:span>print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the <text:s text:c="2"/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in <text:span text:style-name="T1">severity </text:span>from informative all the way to programming errors, as outlined in <text:sequence-ref text:reference-format="category-and-value" text:ref-name="refTable15">Table 4.5</text:sequence-ref>.</text:p>
+    <text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249013"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249013"/></text:h>
+    <text:p text:style-name="P12343">The MESSAGES keyword defines the print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the<text:s/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in severity from informative all the way to programming errors.</text:p>
     <text:p text:style-name="P12343">See <text:a xlink:type="simple" xlink:href="#3.1.7.MESSAGES – Defines Message Print Limits and Stop Limits|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc61634_2479612490">MESSAGES – Define Message Print Limits and Stop Limits</text:bookmark-ref></text:a><text:s/>in the GLOBAL section for a full description.</text:p>
-    
    </text:section>
   </office:text>
  </office:body>

--- a/parts/chapters/subsections/9.3/MESSAGES.fodt
+++ b/parts/chapters/subsections/9.3/MESSAGES.fodt
@@ -4001,11 +4001,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
    </text:user-field-decls>
    <text:p text:style-name="P18776"/>
    <text:section text:style-name="Sect1" text:name="MESSAGES">
-
-<text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249014"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249014"/></text:h>
-    <text:p text:style-name="P12343"><text:span text:style-name="T1">The </text:span>MESSAGES <text:span text:style-name="T1">keyword defines the </text:span>print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the <text:s text:c="2"/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in <text:span text:style-name="T1">severity </text:span>from informative all the way to programming errors, as outlined in <text:sequence-ref text:reference-format="category-and-value" text:ref-name="refTable15">Table 4.5</text:sequence-ref>.</text:p>
+    <text:h text:style-name="P17562" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc61634_247961249014"/>MESSAGES – Define Message Print Limits and Stop Limits<text:bookmark-end text:name="__RefHeading___Toc61634_247961249014"/></text:h>
+    <text:p text:style-name="P12343">The MESSAGES keyword defines the print and stops levels for various messages. The “print limits” set the maximum number of messages that will be printed, after which no more messages will be printed and the<text:s/>“stop limits” terminate the run when these limits are exceeded. There are six levels of message that increase in severity from informative all the way to programming errors.</text:p>
     <text:p text:style-name="P15991">See <text:a xlink:type="simple" xlink:href="#3.1.7.MESSAGES – Defines Message Print Limits and Stop Limits|outline" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:bookmark-ref text:reference-format="text" text:ref-name="__RefHeading___Toc61634_2479612490">MESSAGES – Define Message Print Limits and Stop Limits</text:bookmark-ref></text:a><text:s/>in the GLOBAL section for a full description.</text:p>
-    
    </text:section>
   </office:text>
  </office:body>


### PR DESCRIPTION
The table references are unnecessary as there is a link to the page containing the table.