### PR TITLE
Fix figure reference in GRUPNET

### DIFF
--- a/parts/chapters/subsections/12.3/GRUPNET.fodt
+++ b/parts/chapters/subsections/12.3/GRUPNET.fodt
@@ -5139,7 +5139,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
     <text:p text:style-name="P86">MANI-E2 <text:s/>1* <text:s text:c="4"/>9 <text:s text:c="5"/>4* <text:s text:c="53"/>/</text:p>
     <text:p text:style-name="P86">/</text:p>
     <text:p text:style-name="P81"/>
-    <text:p text:style-name="P84">Here the FIELD controlling pressure is set at 20 barsa and the same limit is used for group PROD which sits directly under the FIELD group (see <text:sequence-ref text:reference-format="category-and-value" text:ref-name="ref0">Figure 12.4</text:sequence-ref>).</text:p>
+    <text:p text:style-name="P84">Here the FIELD controlling pressure is set at 20 barsa and the same limit is used for group PROD which sits directly under the FIELD group (see <text:reference-ref text:reference-format="text" text:ref-name="REF_FIGURE_NORNE_GROUP_TRE___EXAMPLE_12_3">Figure 12.4</text:reference-ref>).</text:p>
     <text:p text:style-name="P81"/>
    </text:section>
   </office:text>

--- a/parts/chapters/subsections/12.3/GRUPTREE.fodt
+++ b/parts/chapters/subsections/12.3/GRUPTREE.fodt
@@ -4671,7 +4671,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
            AAAASUVORK5CYII=
           </office:binary-data>
          </draw:image>
-        </draw:frame>Figure <text:sequence text:ref-name="refFigure89" text:name="Figure" text:formula="ooow:Figure+1" style:num-format="1">12.4</text:sequence>: Norne Group Tree Hierarchy Example</text:p>
+        </draw:frame><text:reference-mark-start text:name="REF_FIGURE_NORNE_GROUP_TRE___EXAMPLE_12_3"/>Figure <text:sequence text:ref-name="refFigure89" text:name="Figure" text:formula="ooow:Figure+1" style:num-format="1">12.4</text:sequence><text:reference-mark-end text:name="REF_FIGURE_NORNE_GROUP_TRE___EXAMPLE_12_3"/>: Norne Group Tree Hierarchy Example</text:p>
       </draw:text-box>
      </draw:frame></text:p>
     <text:p text:style-name="P11341"/>


### PR DESCRIPTION
Replaces PR #344

I have wrapped the Figure number 'Figure 12.4' in GRUPTREE in a reference and tried to give it a unique ref-name. This ref-name is then cross-referenced from GRUPNET. I have successfully tested the links in main.fodt and in the exported main.PDF.
