### PR TITLE
ADDREG, COPYREG, etc. and MULTREGP, MULTREGT, etc. Add Note on Default Region 

### DIFF
--- a/parts/chapters/subsections/6.3/ADDREG.fodt
+++ b/parts/chapters/subsections/6.3/ADDREG.fodt
@@ -4677,6 +4677,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
          <text:p text:style-name="P19087">Where the REGION NUMBER should be less than or equal to the maximum number of regions as defined on the REGDIMS keyword for the FIPNUM and OPERNUM arrays or the GRIDOPTS keyword for the MULTNUM array in the RUNSPEC section.</text:p>
         </text:list-item>
         <text:list-item>
+         <text:p text:style-name="P19087">If the GRIDOPTS keyword is not present in the RUNSPEC section or if the GRIDOPTS keyword is present but the maximum number of MULTNUM regions (NRMULT) equals zero then REGION ARRAY will default to F for the FLUXNUM array.</text:p>
+        </text:list-item>
+        <text:list-item>
          <text:p text:style-name="P18901">Each record must be terminated by a “/” and the keyword is terminated by a “/”.</text:p>
         </text:list-item>
        </text:list>

--- a/parts/chapters/subsections/6.3/COPYREG.fodt
+++ b/parts/chapters/subsections/6.3/COPYREG.fodt
@@ -4721,6 +4721,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
          <text:p text:style-name="P19101">Where the REGION NUMBER should be less than or equal to the maximum number of regions as defined on the REGDIMS keyword for the FIPNUM and OPERNUM arrays or the GRIDOPTS keyword for the MULTNUM array in the RUNSPEC section.</text:p>
         </text:list-item>
         <text:list-item>
+         <text:p text:style-name="P19101">If the GRIDOPTS keyword is not present in the RUNSPEC section or if the GRIDOPTS keyword is present but the maximum number of MULTNUM regions (NRMULT) equals zero then REGION ARRAY will default to F for the FLUXNUM array.</text:p>
+        </text:list-item>
+        <text:list-item>
          <text:p text:style-name="P19052">Each record must be terminated by a “/” and the keyword is terminated by a “/”.</text:p>
         </text:list-item>
        </text:list>

--- a/parts/chapters/subsections/6.3/EQUALREG.fodt
+++ b/parts/chapters/subsections/6.3/EQUALREG.fodt
@@ -4697,6 +4697,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
          <text:p text:style-name="P19102">Where the REGION NUMBER should be less than or equal to the maximum number of regions as defined on the REGDIMS keyword for the FIPNUM and OPERNUM arrays or the GRIDOPTS keyword for the MULTNUM array in the RUNSPEC section.</text:p>
         </text:list-item>
         <text:list-item>
+         <text:p text:style-name="P19102">If the GRIDOPTS keyword is not present in the RUNSPEC section or if the GRIDOPTS keyword is present but the maximum number of MULTNUM regions (NRMULT) equals zero then REGION ARRAY will default to F for the FLUXNUM array.</text:p>
+        </text:list-item>
+        <text:list-item>
          <text:p text:style-name="P18963">Each record must be terminated by a “/” and the keyword is terminated by a “/”.</text:p>
         </text:list-item>
        </text:list>

--- a/parts/chapters/subsections/6.3/MULTIREG.fodt
+++ b/parts/chapters/subsections/6.3/MULTIREG.fodt
@@ -4665,6 +4665,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
          <text:p text:style-name="P19103">Where the REGION should be less than or equal to the maximum number of regions as defined on the REGDIMS keyword for the FIPNUM and OPERNUM arrays or the GRIDOPTS keyword for the MULTNUM array in the RUNSPEC section.</text:p>
         </text:list-item>
         <text:list-item>
+         <text:p text:style-name="P19103">If the GRIDOPTS keyword is not present in the RUNSPEC section or if the GRIDOPTS keyword is present but the maximum number of MULTNUM regions (NRMULT) equals zero then REGION ARRAY will default to F for the FLUXNUM array.</text:p>
+        </text:list-item>
+        <text:list-item>
          <text:p text:style-name="P18971">Each record must be terminated by a “/” and the keyword is terminated by a “/”.</text:p>
         </text:list-item>
        </text:list>

--- a/parts/chapters/subsections/6.3/MULTIREG.fodt
+++ b/parts/chapters/subsections/6.3/MULTIREG.fodt
@@ -4624,9 +4624,10 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       </table:table-cell>
       <table:table-cell table:style-name="Table146.A2" office:value-type="string">
        <text:p text:style-name="P3658">REGION</text:p>
+       <text:p text:style-name="P3658">NUMBER</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table146.A2" office:value-type="string">
-       <text:p text:style-name="P3655">REGION is a positive integer representing the region for which the CONSTANT in (2) should be applied.</text:p>
+       <text:p text:style-name="P3655">REGION NUMBER is a positive integer representing the region for which the CONSTANT in (2) should be applied.</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table146.D2" office:value-type="string">
        <text:p text:style-name="P3647">None</text:p>
@@ -4637,10 +4638,11 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P1932">4</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table146.A2" office:value-type="string">
+       <text:p text:style-name="P3658">REGION</text:p>
        <text:p text:style-name="P3658">ARRAY</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table146.A2" office:value-type="string">
-       <text:p text:style-name="P3658">The ARRAY to use for applying the CONSTANT in (2) based on the REGION in (3). <text:s/>ARRAY can have the following values:</text:p>
+       <text:p text:style-name="P3658">The REGION ARRAY to use for applying the CONSTANT in (2) based on the REGION NUMBER in (3). <text:s/>REGION ARRAY can have the following values:</text:p>
        <text:list xml:id="list105911656265534" text:continue-list="list105910354815294" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
          <text:p text:style-name="P19111">F for the FLUXNUM array</text:p>
@@ -4662,7 +4664,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P1458">Notes:</text:p>
        <text:list xml:id="list4140141660" text:style-name="L65">
         <text:list-item text:start-value="1">
-         <text:p text:style-name="P19103">Where the REGION should be less than or equal to the maximum number of regions as defined on the REGDIMS keyword for the FIPNUM and OPERNUM arrays or the GRIDOPTS keyword for the MULTNUM array in the RUNSPEC section.</text:p>
+         <text:p text:style-name="P19103">Where the REGION NUMBER should be less than or equal to the maximum number of regions as defined on the REGDIMS keyword for the FIPNUM and OPERNUM arrays or the GRIDOPTS keyword for the MULTNUM array in the RUNSPEC section.</text:p>
         </text:list-item>
         <text:list-item>
          <text:p text:style-name="P19103">If the GRIDOPTS keyword is not present in the RUNSPEC section or if the GRIDOPTS keyword is present but the maximum number of MULTNUM regions (NRMULT) equals zero then REGION ARRAY will default to F for the FLUXNUM array.</text:p>

--- a/parts/chapters/subsections/6.3/MULTREGD.fodt
+++ b/parts/chapters/subsections/6.3/MULTREGD.fodt
@@ -4292,7 +4292,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P3659">REGION1</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1395.C7" office:value-type="string">
-       <text:p text:style-name="P3659">A positive integer value that defines the from REGION number for which the CONSTANT in (2) should be applied.</text:p>
+       <text:p text:style-name="P3659">A positive integer value that defines the from REGION number for which the CONSTANT in (3) should be applied.</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1395.D7" office:value-type="string">
        <text:p text:style-name="P3250">None</text:p>
@@ -4306,7 +4306,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P3659">REGION2</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1395.C7" office:value-type="string">
-       <text:p text:style-name="P3659">A positive integer value that defines the to REGION number for which the CONSTANT in (2) should be applied.</text:p>
+       <text:p text:style-name="P3659">A positive integer value that defines the to REGION number for which the CONSTANT in (3) should be applied.</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1395.D7" office:value-type="string">
        <text:p text:style-name="P3250">None</text:p>

--- a/parts/chapters/subsections/6.3/MULTREGD.fodt
+++ b/parts/chapters/subsections/6.3/MULTREGD.fodt
@@ -4263,7 +4263,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
      </table:table-row>
     </table:table>
     <text:h text:style-name="P18422" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc296623_15761773882"/>Description<text:bookmark-end text:name="__RefHeading___Toc296623_15761773882"/></text:h>
-    <text:p text:style-name="_40_TextBody">The MULTREGT keyword multiplies the diffusivity between two regions by a constant. The region number array can be FLUXNUM, MULTNUM or OPERNUM and these arrays must be defined and be available before the MULTREGT keyword is read by the simulator. The constant should be a real number. </text:p>
+    <text:p text:style-name="_40_TextBody">The MULTREGD keyword multiplies the diffusivity between two regions by a constant. The region number array can be FLUXNUM, MULTNUM or OPERNUM and these arrays must be defined and be available before the MULTREGD keyword is read by the simulator. The constant should be a real number. </text:p>
     <text:p text:style-name="_40_TextBody">This keyword is not supported by OPM Flow but would change the results if supported so the simulation will be stopped. </text:p>
     <table:table table:name="Table1395" table:style-name="Table1395">
      <table:table-column table:style-name="Table1395.A"/>
@@ -4370,10 +4370,11 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P4241">6</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1395.B7" office:value-type="string">
+       <text:p text:style-name="P3659">REGION</text:p>
        <text:p text:style-name="P3659">ARRAY</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1395.C7" office:value-type="string">
-       <text:p text:style-name="P3659">The ARRAY to use for applying the CONSTANT in (2) based on the ARRAY in (1). <text:s/>ARRAY can have the following values:</text:p>
+       <text:p text:style-name="P3659">The REGION ARRAY to use for applying the CONSTANT in (3) based on the regions REGION1 and REGION2 in (1 and 2). <text:s/>REGION ARRAY can have the following values:</text:p>
        <text:list xml:id="list105912015054820" text:continue-list="list105911559142812" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
          <text:p text:style-name="P19112">F for the FLUXNUM array</text:p>
@@ -4396,6 +4397,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:list xml:id="list2425202354" text:style-name="L66">
         <text:list-item text:start-value="1">
          <text:p text:style-name="P19104">Where REGION1 and REGION2 should be less than or equal to the maximum number of regions as defined on the REGDIMS keyword for the FIPNUM and OPERNUM arrays or the GRIDOPTS keyword for the MULTNUM array in the RUNSPEC section.</text:p>
+        </text:list-item>
+        <text:list-item>
+         <text:p text:style-name="P19104">If the GRIDOPTS keyword is not present in the RUNSPEC section or if the GRIDOPTS keyword is present but the maximum number of MULTNUM regions (NRMULT) equals zero then REGION ARRAY will default to F for the FLUXNUM array.</text:p>
         </text:list-item>
         <text:list-item>
          <text:p text:style-name="P18972">Each record must be terminated by a “/” and the keyword is terminated by a “/”.</text:p>

--- a/parts/chapters/subsections/6.3/MULTREGD.fodt
+++ b/parts/chapters/subsections/6.3/MULTREGD.fodt
@@ -4334,7 +4334,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P4236">DIR</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1395.C7" office:value-type="string">
-       <text:p text:style-name="P4236">A character string that defines the direction to apply the diffusivity multiplier between the two regions, should be set to one of the following X, Y, Z, XY, XZ, YZ or XYZ.</text:p>
+       <text:p text:style-name="P4236">A character string that defines the direction to apply the diffusivity multiplier between the two regions, should be set to one of the following X, Y, Z, XY, XZ, YZ, or XYZ.</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1395.D7" office:value-type="string">
        <text:p text:style-name="P4239">XYZ</text:p>

--- a/parts/chapters/subsections/6.3/MULTREGD.fodt
+++ b/parts/chapters/subsections/6.3/MULTREGD.fodt
@@ -4334,7 +4334,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P4236">DIR</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1395.C7" office:value-type="string">
-       <text:p text:style-name="P4236">A character string that defines the direction to apply the diffusivity multiplier between the two regions, should be set to one of the following X, Y, Z, XY, YX, XZ, or XYZ.</text:p>
+       <text:p text:style-name="P4236">A character string that defines the direction to apply the diffusivity multiplier between the two regions, should be set to one of the following X, Y, Z, XY, XZ, YZ or XYZ.</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1395.D7" office:value-type="string">
        <text:p text:style-name="P4239">XYZ</text:p>

--- a/parts/chapters/subsections/6.3/MULTREGH.fodt
+++ b/parts/chapters/subsections/6.3/MULTREGH.fodt
@@ -4295,7 +4295,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P3659">REGION1</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1397.C7" office:value-type="string">
-       <text:p text:style-name="P3659">A positive integer value that defines the from REGION number for which the CONSTANT in (2) should be applied.</text:p>
+       <text:p text:style-name="P3659">A positive integer value that defines the from REGION number for which the CONSTANT in (3) should be applied.</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1397.D7" office:value-type="string">
        <text:p text:style-name="P3250">None</text:p>
@@ -4309,7 +4309,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P3659">REGION2</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1397.C7" office:value-type="string">
-       <text:p text:style-name="P3659">A positive integer value that defines the to REGION number for which the CONSTANT in (2) should be applied.</text:p>
+       <text:p text:style-name="P3659">A positive integer value that defines the to REGION number for which the CONSTANT in (3) should be applied.</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1397.D7" office:value-type="string">
        <text:p text:style-name="P3250">None</text:p>
@@ -4337,7 +4337,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P4236">DIR</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1397.C7" office:value-type="string">
-       <text:p text:style-name="P4236">A character string that defines the direction to apply the thermal conductivity multiplier between the two regions, should be set to one of the following X, Y, Z, XY, YX, XZ, or XYZ.</text:p>
+       <text:p text:style-name="P4236">A character string that defines the direction to apply the thermal conductivity multiplier between the two regions, should be set to one of the following X, Y, Z, XY, XZ, YZ or XYZ.</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1397.D7" office:value-type="string">
        <text:p text:style-name="P4239">XYZ</text:p>
@@ -4373,10 +4373,11 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P4241">6</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1397.B7" office:value-type="string">
+       <text:p text:style-name="P3659">REGION</text:p>
        <text:p text:style-name="P3659">ARRAY</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1397.C7" office:value-type="string">
-       <text:p text:style-name="P3659">The ARRAY to use for applying the CONSTANT in (2) based on the ARRAY in (1). <text:s/>ARRAY can have the following values:</text:p>
+       <text:p text:style-name="P3659">The REGION ARRAY to use for applying the CONSTANT in (3) based on the regions REGION1 and REGION2 in (1 and 2). <text:s/>REGION ARRAY can have the following values:</text:p>
        <text:list xml:id="list105912254054751" text:continue-list="list105912099785144" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
          <text:p text:style-name="P19112">F for the FLUXNUM array.</text:p>
@@ -4399,6 +4400,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:list xml:id="list1608041977" text:style-name="L67">
         <text:list-item text:start-value="1">
          <text:p text:style-name="P19105">Where REGION1 and REGION2 should be less than or equal to the maximum number of regions as defined on the REGDIMS keyword for the FIPNUM and OPERNUM arrays or the GRIDOPTS keyword for the MULTNUM array in the RUNSPEC section.</text:p>
+        </text:list-item>
+        <text:list-item>
+         <text:p text:style-name="P19105">If the GRIDOPTS keyword is not present in the RUNSPEC section or if the GRIDOPTS keyword is present but the maximum number of MULTNUM regions (NRMULT) equals zero then REGION ARRAY will default to F for the FLUXNUM array.</text:p>
         </text:list-item>
         <text:list-item>
          <text:p text:style-name="P18973">Each record must be terminated by a “/” and the keyword is terminated by a “/”.</text:p>

--- a/parts/chapters/subsections/6.3/MULTREGH.fodt
+++ b/parts/chapters/subsections/6.3/MULTREGH.fodt
@@ -4337,7 +4337,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P4236">DIR</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1397.C7" office:value-type="string">
-       <text:p text:style-name="P4236">A character string that defines the direction to apply the thermal conductivity multiplier between the two regions, should be set to one of the following X, Y, Z, XY, XZ, YZ or XYZ.</text:p>
+       <text:p text:style-name="P4236">A character string that defines the direction to apply the thermal conductivity multiplier between the two regions, should be set to one of the following X, Y, Z, XY, XZ, YZ, or XYZ.</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table1397.D7" office:value-type="string">
        <text:p text:style-name="P4239">XYZ</text:p>

--- a/parts/chapters/subsections/6.3/MULTREGP.fodt
+++ b/parts/chapters/subsections/6.3/MULTREGP.fodt
@@ -4268,10 +4268,11 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P2094">3</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table302.A2" office:value-type="string">
+       <text:p text:style-name="P3660">REGION</text:p>
        <text:p text:style-name="P3660">ARRAY</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table302.A2" office:value-type="string">
-       <text:p text:style-name="P3660">The ARRAY to use for applying the CONSTANT in (2) based on the REGION in (1). <text:s/>ARRAY can have the following values:</text:p>
+       <text:p text:style-name="P3660">The REGION ARRAY to use for applying the CONSTANT in (2) based on the REGION in (1). <text:s/>ARRAY can have the following values:</text:p>
        <text:list xml:id="list105911181623006" text:continue-list="list105912254054751" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
          <text:p text:style-name="P19113">F for the FLUXNUM array.</text:p>
@@ -4294,6 +4295,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:list xml:id="list2320241163" text:style-name="L68">
         <text:list-item text:start-value="1">
          <text:p text:style-name="P19106">Where the REGION should be less than or equal to the maximum number of regions as defined on the REGDIMS keyword for the FIPNUM and OPERNUM arrays or the GRIDOPTS keyword for the MULTNUM array in the RUNSPEC section.</text:p>
+        </text:list-item>
+        <text:list-item>
+         <text:p text:style-name="P19106">If the GRIDOPTS keyword is not present in the RUNSPEC section or if the GRIDOPTS keyword is present but the maximum number of MULTNUM regions (NRMULT) equals zero then REGION ARRAY will default to F for the FLUXNUM array.</text:p>
         </text:list-item>
         <text:list-item>
          <text:p text:style-name="P18974">Each record must be terminated by a “/” and the keyword is terminated by a “/”.</text:p>

--- a/parts/chapters/subsections/6.3/MULTREGT.fodt
+++ b/parts/chapters/subsections/6.3/MULTREGT.fodt
@@ -4384,10 +4384,11 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P4242">6</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table304.A2" office:value-type="string">
+       <text:p text:style-name="P3661">REGION</text:p>
        <text:p text:style-name="P3661">ARRAY</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table304.A2" office:value-type="string">
-       <text:p text:style-name="P3661">A single character that defines the ARRAY that is used to specify the regions identified by REGION1 and REGION2. <text:s/>ARRAY can have the following values:</text:p>
+       <text:p text:style-name="P3661">A single character that defines the REGION ARRAY that is used to specify the regions identified by REGION1 and REGION2. <text:s/>REGION ARRAY can have the following values:</text:p>
        <text:list xml:id="list105911461654926" text:continue-list="list105912108003076" text:style-name="_40_NumberedListTable">
         <text:list-item text:start-value="1">
          <text:p text:style-name="P19114">F for the FLUXNUM array</text:p>
@@ -4416,6 +4417,9 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
         </text:list-item>
         <text:list-item>
          <text:p text:style-name="P19107">If REGION1 and REGION2 are equal and positive then all the transmissibilities within that region as well as the transmissibilities between that region and all other regions will be multiplied.</text:p>
+        </text:list-item>
+        <text:list-item>
+         <text:p text:style-name="P19107">If the GRIDOPTS keyword is not present in the RUNSPEC section or if the GRIDOPTS keyword is present but the maximum number of MULTNUM regions (NRMULT) equals zero then REGION ARRAY will default to F for the FLUXNUM array.</text:p>
         </text:list-item>
         <text:list-item>
          <text:p text:style-name="P18975">Each record must be terminated by a “/” and the keyword is terminated by a “/”.</text:p>


### PR DESCRIPTION
* If the REGION array is not indicated, the
* default region to use in the xxxREG keywords depends on the GRIDOPTS
* keyword:
*
* 1. If GRIDOPTS is present, and the NRMULT item is greater than zero,
* the xxxREG keywords will default to use the MULTNUM region.
*
* 2. If the GRIDOPTS keyword is not present - or the NRMULT item equals
* zero, the xxxREG keywords will default to use the FLUXNUM keyword.
*