### PR TITLE
Script to extract keyword URIs

### DIFF
--- a/scripts/python/pyproject.toml
+++ b/scripts/python/pyproject.toml
@@ -46,6 +46,7 @@ fodt-splitter = "fodt.splitter:main"
 fodt-validate-document = "fodt.validate_automatic_styles:validate"
 fodt-xml-sax-filter-all = "fodt.xml_sax_filter_all:xml_sax_filter_all"
 fodt-xml-sax-filter-meta = "fodt.xml_filter_meta:xml_sax_filter_meta"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/scripts/python/pyproject.toml
+++ b/scripts/python/pyproject.toml
@@ -28,6 +28,7 @@ fodt-extract-xml-tag = "fodt.splitter:extract_xml_tag"
 fodt-fix-ignored-keywords = "fodt.fix_ignored:fix_ignored"
 fodt-fix-footer-style = "fodt.fix_footer_style:fix_footer_style"
 fodt-fix-letter-k-footer = "fodt.fix_letter_k_footer:fix_letter_k_footer"
+fodt-gen-kw-uri-map = "fodt.keyword_linker:gen_kw_uri_map"
 fodt-remove-bookmarks-from-master-styles = "fodt.remove_bookmarks:remove_bookmarks_from_master_styles"
 fodt-remove-chapters = "fodt.splitter:remove_chapters"
 fodt-remove-elements = "fodt.splitter:remove_elements"
@@ -45,7 +46,6 @@ fodt-splitter = "fodt.splitter:main"
 fodt-validate-document = "fodt.validate_automatic_styles:validate"
 fodt-xml-sax-filter-all = "fodt.xml_sax_filter_all:xml_sax_filter_all"
 fodt-xml-sax-filter-meta = "fodt.xml_filter_meta:xml_sax_filter_meta"
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/scripts/python/src/fodt/add_keyword.py
+++ b/scripts/python/src/fodt/add_keyword.py
@@ -13,7 +13,7 @@ import click
 
 from fodt.constants import ClickOptions, Directories, FileExtensions, KeywordStatus, Regex
 from fodt.create_subdocument import CreateSubDocument3
-from fodt.helpers import Helpers
+from fodt import helpers
 from fodt.remove_subsections import RemoveSubSections
 from fodt.templates import Templates
 from fodt.xml_helpers import XMLHelper
@@ -241,8 +241,8 @@ class AddKeyword():
         status: KeywordStatus,
         appendix: bool
     ) -> None:
-        self.maindir = Helpers.get_maindir(maindir)
-        self.keyword_dir = Helpers.get_keyword_dir(keyword_dir, self.maindir)
+        self.maindir = helpers.get_maindir(maindir)
+        self.keyword_dir = helpers.get_keyword_dir(keyword_dir, self.maindir)
         self.keyword = keyword
         self.chapter = chapter
         self.section = section
@@ -259,16 +259,16 @@ class AddKeyword():
 
     def add_keyword(self) -> None:
         self.documentdir = Path(self.maindir) / Directories.chapters
-        keyw_list = Helpers.read_keyword_order_v2(self.keyword_dir, self.chapter, self.section)
-        #keyw_list = Helpers.read_keyword_order(self.documentdir, self.chapter, self.section)
+        keyw_list = helpers.read_keyword_order_v2(self.keyword_dir, self.chapter, self.section)
+        #keyw_list = helpers.read_keyword_order(self.documentdir, self.chapter, self.section)
         keywords = set(keyw_list)
         if self.keyword in keywords:
             logging.info(f"Keyword {self.keyword} already exists. Aborting.")
             return
         keywords.add(self.keyword)
         keyw_list = sorted(list(keywords))
-        #Helpers.write_keyword_order(self.documentdir, self.chapter, self.section, keyw_list)
-        Helpers.write_keyword_order_v2(self.keyword_dir, self.chapter, self.section, keyw_list)
+        #helpers.write_keyword_order(self.documentdir, self.chapter, self.section, keyw_list)
+        helpers.write_keyword_order_v2(self.keyword_dir, self.chapter, self.section, keyw_list)
         logging.info(f"Added keyword {self.keyword} to chapter {self.chapter}, section {self.section}.")
         return
 
@@ -296,9 +296,9 @@ class AddKeyword():
     def update_chapter_document(self) -> None:
         logging.info(f"Updating chapter document {self.chapter}.")
         filename = self.documentdir / f"{self.chapter}.{FileExtensions.fodt}"
-        source_file = Helpers.create_backup_document(filename)
+        source_file = helpers.create_backup_document(filename)
         dest_file = filename
-        replace_callback = Helpers.replace_section_callback
+        replace_callback = helpers.replace_section_callback
         # NOTE: This will remove the subsection the first time it is called, and then
         #     if it is called again (for example using add-keyword), it will remove
         #     the inserted <text:section> tag that was inserted by the first call.
@@ -369,7 +369,7 @@ def add_keyword(
     appendix: bool
 ) -> None:
     logging.basicConfig(level=logging.INFO)
-    (chapter, section) = Helpers.split_section(section)
+    (chapter, section) = helpers.split_section(section)
     try:
         status = KeywordStatus[status.upper()]
     except ValueError:

--- a/scripts/python/src/fodt/add_keyword.py
+++ b/scripts/python/src/fodt/add_keyword.py
@@ -242,7 +242,7 @@ class AddKeyword():
         appendix: bool
     ) -> None:
         self.maindir = helpers.get_maindir(maindir)
-        self.keyword_dir = helpers.get_keyword_dir(keyword_dir, self.maindir)
+        self.keyword_dir = helpers.get_keyword_dir(keyword_dir)
         self.keyword = keyword
         self.chapter = chapter
         self.section = section

--- a/scripts/python/src/fodt/constants.py
+++ b/scripts/python/src/fodt/constants.py
@@ -53,6 +53,7 @@ class FileExtensions():
 
 class FileNames():
     keywords = "keywords.txt"
+    kw_uri_map = "kw_uri_map.txt"
     main_document = "main.fodt"
     master_styles_fn = "master-styles.xml"
     office_attr_fn = "office_attrs.txt"

--- a/scripts/python/src/fodt/create_subdocument.py
+++ b/scripts/python/src/fodt/create_subdocument.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from fodt.automatic_styles_filter import AutomaticStylesFilter2, AutomaticStylesFilter3
 from fodt.constants import Directories, FileExtensions, FileNames, MetaSections
 from fodt.exceptions import InputException
-from fodt.helpers import Helpers
+from fodt import helpers
 from fodt.xml_helpers import XMLHelper
 from fodt.styles_filter import StylesFilter
 
@@ -36,7 +36,7 @@ class CreateSubDocument():
             logging.info(f"Created FODT subdocument {outputfile}")
 
     def create_subsection_template(self, part: str, part_extra: str|None) -> str:
-        template = Helpers.read_keyword_template()
+        template = helpers.read_keyword_template()
         part_bookmark = f"{part}_{part_extra}" if part_extra is not None else part
         template = re.sub(r"###KEYWORD_NAME_BOOKMARK###", part_bookmark, template)
         template = re.sub(r"###KEYWORD_NAME###", part, template)
@@ -165,8 +165,8 @@ class CreateSubDocument2(CreateSubDocument):
         self.outputdir = self.documentdir / Directories.subsections
         self.is_chapter = False
         parts = self.get_parts()
-        keyw_list = Helpers.read_keyword_order(self.documentdir, chapter, section)
-        self.keywords = Helpers.keywords_inverse_map(keyw_list)
+        keyw_list = helpers.read_keyword_order(self.documentdir, chapter, section)
+        self.keywords = helpers.keywords_inverse_map(keyw_list)
         self.add_keyword = False
         self.create_documents(parts)
 
@@ -202,7 +202,7 @@ class CreateSubDocument3(CreateSubDocument):
         self.is_chapter = False
         parts = [self.keyword]
         parts_extra = [f"{self.chapter}_{self.section}"]
-        keyw_list = Helpers.read_keyword_order_v2(self.keyword_dir, chapter, section)
-        self.keywords = Helpers.keywords_inverse_map(keyw_list)
+        keyw_list = helpers.read_keyword_order_v2(self.keyword_dir, chapter, section)
+        self.keywords = helpers.keywords_inverse_map(keyw_list)
         self.add_keyword = True
         self.create_documents(parts, parts_extra)

--- a/scripts/python/src/fodt/extract_section.py
+++ b/scripts/python/src/fodt/extract_section.py
@@ -13,7 +13,7 @@ from fodt.constants import (
 )
 from fodt.automatic_styles_filter import AutomaticStylesFilter4
 from fodt.exceptions import ParsingException
-from fodt.helpers import Helpers
+from fodt import helpers
 from fodt.styles_filter import StylesFilter
 from fodt.xml_helpers import XMLHelper
 
@@ -200,7 +200,7 @@ class ExtractAndRemoveSectionFromChapter:
         parser = xml.sax.make_parser()
         handler = ExtractAndRemoveHandler(self.chapter, self.section)
         parser.setContentHandler(handler)
-        fn = Helpers.chapter_fodt_file_path(self.maindir, self.chapter)
+        fn = helpers.chapter_fodt_file_path(self.maindir, self.chapter)
         parser.parse(fn)
         return (handler.get_section(), handler.get_doc(), handler.get_styles())
 
@@ -228,7 +228,7 @@ class ExtractSection:
         self.create_section_file(section_txt, styles)
 
     def write_updated_chapter(self, doc: str) -> None:
-        fn = Helpers.chapter_fodt_file_path(self.maindir, self.chapter)
+        fn = helpers.chapter_fodt_file_path(self.maindir, self.chapter)
         with open(fn, "w", encoding='utf8') as f:
             f.write(doc)
         logging.info(f"Wrote updated chapter file to {fn}.")
@@ -250,7 +250,7 @@ class ExtractSection:
 def extract_section(maindir: str, section: str) -> None:
     """Extract the appendix from a FODT file."""
     logging.basicConfig(level=logging.INFO)
-    (chapter, section) = Helpers.split_section(section)
+    (chapter, section) = helpers.split_section(section)
     logging.info(f"Extracting section {section} from chapter {chapter}.")
     extractor = ExtractSection(maindir, chapter, section)
     extractor.extract()

--- a/scripts/python/src/fodt/extract_subsections.py
+++ b/scripts/python/src/fodt/extract_subsections.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from fodt.constants import AutomaticStyles, Directories, FileNames, FileExtensions
 from fodt.exceptions import HandlerDoneException, InputException, ParsingException
-from fodt.helpers import Helpers
+from fodt import helpers
 from fodt.xml_helpers import XMLHelper
 
 class PartsHandler(xml.sax.handler.ContentHandler):
@@ -179,10 +179,10 @@ class ExtractSubSections():
         section: int,
     ) -> None:
         parser = xml.sax.make_parser()
-        keyword_file = Helpers.keyword_file(outputdir, chapter, section)
+        keyword_file = helpers.keyword_file(outputdir, chapter, section)
         predefined_keywords = None
         if keyword_file.exists():
-            predefined_keywords = Helpers.read_keyword_order(outputdir, chapter, section)
+            predefined_keywords = helpers.read_keyword_order(outputdir, chapter, section)
         handler = PartsHandler(outputdir, chapter, section, predefined_keywords)
         parser.setContentHandler(handler)
         try:

--- a/scripts/python/src/fodt/helpers.py
+++ b/scripts/python/src/fodt/helpers.py
@@ -48,7 +48,7 @@ def derive_maindir_from_filename(filename: str) -> Path:
         filename = filename.parent
     # This should never be reached
 
-def get_keyword_dir(keyword_dir: str, maindir: Path) -> str:
+def get_keyword_dir(keyword_dir: str|None) -> Path:
     if keyword_dir is None:
         # Default value for keyword_dir is a relative path like "../../keyword-names"
         keyword_dir = Path(f'../../{Directories.keyword_names}')

--- a/scripts/python/src/fodt/helpers.py
+++ b/scripts/python/src/fodt/helpers.py
@@ -6,273 +6,253 @@ from fodt.constants import Directories, FileExtensions, FileNames
 from fodt.exceptions import InputException
 from fodt.xml_helpers import XMLHelper
 
-class Helpers:
+def chapter_fodt_file_path(
+    outputdir: str,
+    chapter: str,
+) -> Path:
+    filename = (
+        Path(outputdir) /
+        Directories.chapters /
+        f"{chapter}.{FileExtensions.fodt}"
+    )
+    return filename
 
-    @staticmethod
-    def chapter_fodt_file_path(
-        outputdir: str,
-        chapter: str,
-    ) -> Path:
-        filename = (
-            Path(outputdir) /
-            Directories.chapters /
-            f"{chapter}.{FileExtensions.fodt}"
-        )
-        return filename
+def create_backup_document(filename) -> None:
+    outputdir = filename.parent
+    backupdir = outputdir / Directories.backup
+    backupdir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(filename, backupdir)
+    backup_file = backupdir / filename.name
+    return backup_file
 
-    @staticmethod
-    def create_backup_document(filename) -> None:
-        outputdir = filename.parent
-        backupdir = outputdir / Directories.backup
-        backupdir.mkdir(parents=True, exist_ok=True)
-        shutil.copy(filename, backupdir)
-        backup_file = backupdir / filename.name
-        return backup_file
+def derive_maindir_from_filename(filename: str) -> Path:
+    """
+    :param filename: Assumed to be an aboslute path to file inside maindir or subdirectories of maindir.
+    :return: The absolute path to the maindir.
+    """
+    filename = Path(filename)
+    assert filename.is_absolute()
+    # Search parent directories for main.fodt in a directory called "parts"
+    while True:
+        # Check if we have reached the root directory
+        #  filename.parent == filename is True if filename is the root directory
+        if filename.parent == filename:
+            raise FileNotFoundError(f"Could not derive maindir from filename: "
+                  f"Could not find '{FileNames.main_document}' in a directory "
+                  f"called '{Directories.parts}' by searching the parent "
+                  f"directories of filename."
+            )
+        if filename.parent.name == Directories.parts:
+            if (filename.parent / FileNames.main_document).exists():
+                return filename.parent
+        filename = filename.parent
+    # This should never be reached
 
-    @staticmethod
-    def derive_maindir_from_filename(filename: str) -> Path:
-        """
-        :param filename: Assumed to be an aboslute path to file inside maindir or subdirectories of maindir.
-        :return: The absolute path to the maindir.
-        """
-        filename = Path(filename)
-        assert filename.is_absolute()
-        # Search parent directories for main.fodt in a directory called "parts"
-        while True:
-            # Check if we have reached the root directory
-            #  filename.parent == filename is True if filename is the root directory
-            if filename.parent == filename:
-                raise FileNotFoundError(f"Could not derive maindir from filename: "
-                      f"Could not find '{FileNames.main_document}' in a directory "
-                      f"called '{Directories.parts}' by searching the parent "
-                      f"directories of filename."
-                )
-            if filename.parent.name == Directories.parts:
-                if (filename.parent / FileNames.main_document).exists():
-                    return filename.parent
-            filename = filename.parent
-        # This should never be reached
-
-    @staticmethod
-    def get_keyword_dir(keyword_dir: str, maindir: Path) -> str:
-        if keyword_dir is None:
-            # Default value for keyword_dir is a relative path like "../../keyword-names"
-            keyword_dir = Path(f'../../{Directories.keyword_names}')
+def get_keyword_dir(keyword_dir: str, maindir: Path) -> str:
+    if keyword_dir is None:
+        # Default value for keyword_dir is a relative path like "../../keyword-names"
+        keyword_dir = Path(f'../../{Directories.keyword_names}')
+    if not keyword_dir.exists():
+        main_dir = locate_maindir_from_current_dir()
+        keyword_dir = main_dir.parent / Directories.keyword_names
         if not keyword_dir.exists():
-            main_dir = Helpers.locate_maindir_from_current_dir()
-            keyword_dir = main_dir.parent / Directories.keyword_names
-            if not keyword_dir.exists():
-                raise FileNotFoundError(f"Keyword names directory not found.")
-        return keyword_dir
+            raise FileNotFoundError(f"Keyword names directory not found.")
+    return keyword_dir
 
-    @staticmethod
-    def get_maindir(maindir: str) -> Path:
-        """
-        :param maindir: The main directory of the project. Can be relative or absolute.
-        :return: The absolute path to the main directory.
-        """
-        if maindir is None:
-            # Try to find maindir by searching the current working directory and its
-            # parent directories for a file main.fodt inside a directory called parts
-            maindir = Helpers.locate_maindir_from_current_dir()
+def get_maindir(maindir: str) -> Path:
+    """
+    :param maindir: The main directory of the project. Can be relative or absolute.
+    :return: The absolute path to the main directory.
+    """
+    if maindir is None:
+        # Try to find maindir by searching the current working directory and its
+        # parent directories for a file main.fodt inside a directory called parts
+        maindir = locate_maindir_from_current_dir()
+    else:
+        maindir = Path(maindir)
+        if not maindir.is_dir():
+            # The default value for maindir is a relative path like "../../parts"
+            # If it does not exist, try to find maindir by searching the current
+            # working directory and its parent directories. This is better than
+            # raising an exception here I think..
+            maindir = locate_maindir_from_current_dir()
         else:
-            maindir = Path(maindir)
-            if not maindir.is_dir():
-                # The default value for maindir is a relative path like "../../parts"
-                # If it does not exist, try to find maindir by searching the current
-                # working directory and its parent directories. This is better than
-                # raising an exception here I think..
-                maindir = Helpers.locate_maindir_from_current_dir()
-            else:
-                maindir = maindir.absolute()
-        return maindir
+            maindir = maindir.absolute()
+    return maindir
 
-    @staticmethod
-    def keyword_file(outputdir: Path, chapter: int, section: int) -> Path:
-        directory = f"{chapter}.{section}"
-        filename = FileNames.keywords
-        dir_ = outputdir / Directories.info / Directories.keywords / directory
-        file = dir_ / filename
-        return file
+def keyword_file(outputdir: Path, chapter: int, section: int) -> Path:
+    directory = f"{chapter}.{section}"
+    filename = FileNames.keywords
+    dir_ = outputdir / Directories.info / Directories.keywords / directory
+    file = dir_ / filename
+    return file
 
-    @staticmethod
-    def keyword_file_v2(keyword_dir: str, chapter: int, section: int) -> Path:
-        directory = f"{chapter}.{section}"
-        file = Path(keyword_dir) / directory / FileNames.keywords
-        return file
+def keyword_file_v2(keyword_dir: str, chapter: int, section: int) -> Path:
+    directory = f"{chapter}.{section}"
+    file = Path(keyword_dir) / directory / FileNames.keywords
+    return file
 
-    @staticmethod
-    def keyword_fodt_file_path(
-        outputdir: str,
-        chapter: str,
-        section: str,
-        keyword_name: str
-    ) -> Path:
-        directory = f"{chapter}.{section}"
-        filename = (
-            Path(outputdir) /
-            Directories.chapters /
-            Directories.subsections /
-            directory /
-            f"{keyword_name}.{FileExtensions.fodt}"
-        )
-        return filename
+def keyword_fodt_file_path(
+    outputdir: str,
+    chapter: str,
+    section: str,
+    keyword_name: str
+) -> Path:
+    directory = f"{chapter}.{section}"
+    filename = (
+        Path(outputdir) /
+        Directories.chapters /
+        Directories.subsections /
+        directory /
+        f"{keyword_name}.{FileExtensions.fodt}"
+    )
+    return filename
 
-    @staticmethod
-    def keywords_inverse_map(keyw_list: list[str]) -> dict[str, int]:
-        return {keyw_list[i]: i + 1 for i in range(len(keyw_list))}
+def keywords_inverse_map(keyw_list: list[str]) -> dict[str, int]:
+    return {keyw_list[i]: i + 1 for i in range(len(keyw_list))}
 
 
-    @staticmethod
-    def locate_maindir_and_filename(
-        maindir: str,
-        filename: str
-    ) -> tuple[Path, Path]:
-        """
-        :param maindir: The main directory of the project. Can be relative or absolute.
-        :param filename: The filename to locate. Can be relative or absolute. ``filename`` is assumed to be a file in maindir or a file in one of its subdirectories.
-        :return: A tuple of the form (maindir, filename), where both are absolute paths."""
-        filename = Path(filename)
-        maindir = Path(maindir)  # maindir can be absolute or relative
-        # If filename is an absolute path, ignore maindir
-        if filename.is_absolute():
-            assert filename.exists()
-            maindir = Helpers.derive_maindir_from_filename(filename)
-            return maindir, Path(filename)
+def locate_maindir_and_filename(
+    maindir: str,
+    filename: str
+) -> tuple[Path, Path]:
+    """
+    :param maindir: The main directory of the project. Can be relative or absolute.
+    :param filename: The filename to locate. Can be relative or absolute. ``filename`` is assumed to be a file in maindir or a file in one of its subdirectories.
+    :return: A tuple of the form (maindir, filename), where both are absolute paths."""
+    filename = Path(filename)
+    maindir = Path(maindir)  # maindir can be absolute or relative
+    # If filename is an absolute path, ignore maindir
+    if filename.is_absolute():
+        assert filename.exists()
+        maindir = derive_maindir_from_filename(filename)
+        return maindir, Path(filename)
+    else:
+        # Try to find filename by concatenating maindir and filename
+        if not maindir.is_absolute():
+            # If both maindir and filename are relative, make filename relative
+            # to maindir instead of relative to the current working directory
+            maindir_abs = Path.cwd() / maindir
+            filename_abs = maindir_abs / filename
+            if filename_abs.exists():
+                return maindir_abs, filename_abs
         else:
-            # Try to find filename by concatenating maindir and filename
-            if not maindir.is_absolute():
-                # If both maindir and filename are relative, make filename relative
-                # to maindir instead of relative to the current working directory
-                maindir_abs = Path.cwd() / maindir
-                filename_abs = maindir_abs / filename
-                if filename_abs.exists():
-                    return maindir_abs, filename_abs
-            else:
-                filename = maindir / filename
-                if filename.exists():
-                    return maindir, filename
-            # If not found, search for filename relative to the current working directory
-            filename = Path.cwd() / filename
+            filename = maindir / filename
             if filename.exists():
-                maindir = Helpers.derive_maindir_from_filename(filename)
                 return maindir, filename
-        raise FileNotFoundError(f"Could not find '{filename.name}' in a directory "
-                                f"called '{maindir.name}'.")
+        # If not found, search for filename relative to the current working directory
+        filename = Path.cwd() / filename
+        if filename.exists():
+            maindir = derive_maindir_from_filename(filename)
+            return maindir, filename
+    raise FileNotFoundError(f"Could not find '{filename.name}' in a directory "
+                            f"called '{maindir.name}'.")
 
 
-    @staticmethod
-    def locate_maindir_from_current_dir() -> Path:
-        cwd = Path.cwd()
-        # We cannot use derive_maindir_from_filename() here because cwd does not
-        # have to be inside maindir in this case
-        while True:
-            # Check if we have reached the root directory
-            #  cwd.parent == cwd is True if filename is the root directory
-            if cwd.parent == cwd:
-                raise FileNotFoundError(f"Could not derive maindir from cwd: "
-                      f"Could not find '{FileNames.main_document}' in a directory "
-                      f"called '{Directories.parts}' by searching the parent "
-                      f"directories of cwd."
-                )
-            # Check if there is a sibling directory called "parts" with a file main.fodt
-            dir_ = cwd / Directories.parts
-            if dir_.is_dir():
-                if (dir_ / FileNames.main_document).exists():
-                    return dir_
-            cwd = cwd.parent
-        # This line should never be reached
+def locate_maindir_from_current_dir() -> Path:
+    cwd = Path.cwd()
+    # We cannot use derive_maindir_from_filename() here because cwd does not
+    # have to be inside maindir in this case
+    while True:
+        # Check if we have reached the root directory
+        #  cwd.parent == cwd is True if filename is the root directory
+        if cwd.parent == cwd:
+            raise FileNotFoundError(f"Could not derive maindir from cwd: "
+                  f"Could not find '{FileNames.main_document}' in a directory "
+                  f"called '{Directories.parts}' by searching the parent "
+                  f"directories of cwd."
+            )
+        # Check if there is a sibling directory called "parts" with a file main.fodt
+        dir_ = cwd / Directories.parts
+        if dir_.is_dir():
+            if (dir_ / FileNames.main_document).exists():
+                return dir_
+        cwd = cwd.parent
+    # This line should never be reached
 
-    @staticmethod
-    def locate_maindir_from_current_dir() -> Path:
-        cwd = Path.cwd()
-        # We cannot use derive_maindir_from_filename() here because cwd does not
-        # have to be inside maindir in this case
-        while True:
-            # Check if we have reached the root directory
-            #  cwd.parent == cwd is True if filename is the root directory
-            if cwd.parent == cwd:
-                raise FileNotFoundError(f"Could not derive maindir from cwd: "
-                      f"Could not find '{FileNames.main_document}' in a directory "
-                      f"called '{Directories.parts}' by searching the parent "
-                      f"directories of cwd."
-                )
-            # Check if there is a sibling directory called "parts" with a file main.fodt
-            dir_ = cwd / Directories.parts
-            if dir_.is_dir():
-                if (dir_ / FileNames.main_document).exists():
-                    return dir_
-            cwd = cwd.parent
-        # This line should never be reached
+def locate_maindir_from_current_dir() -> Path:
+    cwd = Path.cwd()
+    # We cannot use derive_maindir_from_filename() here because cwd does not
+    # have to be inside maindir in this case
+    while True:
+        # Check if we have reached the root directory
+        #  cwd.parent == cwd is True if filename is the root directory
+        if cwd.parent == cwd:
+            raise FileNotFoundError(f"Could not derive maindir from cwd: "
+                  f"Could not find '{FileNames.main_document}' in a directory "
+                  f"called '{Directories.parts}' by searching the parent "
+                  f"directories of cwd."
+            )
+        # Check if there is a sibling directory called "parts" with a file main.fodt
+        dir_ = cwd / Directories.parts
+        if dir_.is_dir():
+            if (dir_ / FileNames.main_document).exists():
+                return dir_
+        cwd = cwd.parent
+    # This line should never be reached
 
-    @staticmethod
-    def read_keyword_order(outputdir: Path, chapter: int, section: int) -> list[str]:
-        file = Helpers.keyword_file(outputdir, chapter, section)
-        if not file.exists():
-            raise InputException(f"Could not find file {file}.")
-        with open(file, "r", encoding='utf8') as f:
-            keywords = [line.strip() for line in f.readlines()]
-        return keywords
+def read_keyword_order(outputdir: Path, chapter: int, section: int) -> list[str]:
+    file = keyword_file(outputdir, chapter, section)
+    if not file.exists():
+        raise InputException(f"Could not find file {file}.")
+    with open(file, "r", encoding='utf8') as f:
+        keywords = [line.strip() for line in f.readlines()]
+    return keywords
 
-    def read_keyword_order_v2(keyword_dir: str, chapter: int, section: int) -> list[str]:
-        file = Helpers.keyword_file_v2(keyword_dir, chapter, section)
-        if not file.exists():
-            raise InputException(f"Could not find file {file}.")
-        with open(file, "r", encoding='utf8') as f:
-            keywords = [line.strip() for line in f.readlines()]
-        return keywords
+def read_keyword_order_v2(keyword_dir: str, chapter: int, section: int) -> list[str]:
+    file = keyword_file_v2(keyword_dir, chapter, section)
+    if not file.exists():
+        raise InputException(f"Could not find file {file}.")
+    with open(file, "r", encoding='utf8') as f:
+        keywords = [line.strip() for line in f.readlines()]
+    return keywords
 
-    @staticmethod
-    def read_keyword_template() -> str:
-        # NOTE: This template was created from the COLUMNS keyword in section 4.3
-        path = importlib.resources.files("fodt.data").joinpath("keyword_template.xml")
-        with open(path, "r", encoding='utf8') as f:
-            template = f.read()
-        return template
+def read_keyword_template() -> str:
+    # NOTE: This template was created from the COLUMNS keyword in section 4.3
+    path = importlib.resources.files("fodt.data").joinpath("keyword_template.xml")
+    with open(path, "r", encoding='utf8') as f:
+        template = f.read()
+    return template
 
-    @staticmethod
-    def replace_section_callback(part: str, keyword: str) -> str:
-        section = ".".join(part.split(".")[:2])
-        href = f"{Directories.subsections}/{section}/{keyword}.fodt"
-        href = XMLHelper.escape(href)
-        return (f"""<text:section text:style-name="Sect1" text:name="Section{section}:{keyword}" """
-                   f"""text:protected="true">\n"""
-                f"""     <text:section-source xlink:href="{href}" """
-                   f"""text:filter-name="OpenDocument Text Flat XML" """
-                   f"""text:section-name="{keyword}"/>\n"""
-                f"""    </text:section>\n""")
+def replace_section_callback(part: str, keyword: str) -> str:
+    section = ".".join(part.split(".")[:2])
+    href = f"{Directories.subsections}/{section}/{keyword}.fodt"
+    href = XMLHelper.escape(href)
+    return (f"""<text:section text:style-name="Sect1" text:name="Section{section}:{keyword}" """
+               f"""text:protected="true">\n"""
+            f"""     <text:section-source xlink:href="{href}" """
+               f"""text:filter-name="OpenDocument Text Flat XML" """
+               f"""text:section-name="{keyword}"/>\n"""
+            f"""    </text:section>\n""")
 
-    @staticmethod
-    def split_section(section: str) -> tuple[str, str]:
-        parts = section.split(".")
-        if len(parts) != 2:
-            raise ValueError(f"Section must be of the form <chapter>.<section>, but got {section}")
-        # check that chapter and section are integers
-        try:
-            int(parts[0])
-            int(parts[1])
-        except ValueError as e:
-            raise ValueError(f"Section must be of the form <chapter>.<section>, "
-                             f"where <chapter> and <section> are integers, but got {section}")
-        return (parts[0], parts[1])
+def split_section(section: str) -> tuple[str, str]:
+    parts = section.split(".")
+    if len(parts) != 2:
+        raise ValueError(f"Section must be of the form <chapter>.<section>, but got {section}")
+    # check that chapter and section are integers
+    try:
+        int(parts[0])
+        int(parts[1])
+    except ValueError as e:
+        raise ValueError(f"Section must be of the form <chapter>.<section>, "
+                         f"where <chapter> and <section> are integers, but got {section}")
+    return (parts[0], parts[1])
 
 
-    @staticmethod
-    def write_keyword_order(outputdir: Path, chapter: int, section: int,
-                            keywords: list[str]
-    ) -> None:
-        file = Helpers.keyword_file(outputdir, chapter, section)
-        with open(file, "w", encoding='utf8') as f:
-            for keyword in keywords:
-                f.write(f"{keyword}\n")
-        return
+def write_keyword_order(outputdir: Path, chapter: int, section: int,
+                        keywords: list[str]
+) -> None:
+    file = keyword_file(outputdir, chapter, section)
+    with open(file, "w", encoding='utf8') as f:
+        for keyword in keywords:
+            f.write(f"{keyword}\n")
+    return
 
-    @staticmethod
-    def write_keyword_order_v2(keyword_dir: str, chapter: int, section: int,
-                               keywords: list[str]
-    ) -> None:
-        file = Helpers.keyword_file_v2(keyword_dir, chapter, section)
-        with open(file, "w", encoding='utf8') as f:
-            for keyword in keywords:
-                f.write(f"{keyword}\n")
-        return
+def write_keyword_order_v2(keyword_dir: str, chapter: int, section: int,
+                           keywords: list[str]
+) -> None:
+    file = keyword_file_v2(keyword_dir, chapter, section)
+    with open(file, "w", encoding='utf8') as f:
+        for keyword in keywords:
+            f.write(f"{keyword}\n")
+    return

--- a/scripts/python/src/fodt/keyword_linker.py
+++ b/scripts/python/src/fodt/keyword_linker.py
@@ -45,6 +45,8 @@ class ExtractURI_Handler(xml.sax.handler.ContentHandler):
         if name == "text:h":
             if self.in_section:
                 self.in_section = False
+                # The keyword URI must be found within the text:h, since we are done parsing
+                # the tag, we raise an exception here to catch an unexpected situation.
                 raise ParsingException("Keyword name not found in document")
         elif self.in_section and name == "text:bookmark-start":
             if self.in_bookmark:

--- a/scripts/python/src/fodt/keyword_linker.py
+++ b/scripts/python/src/fodt/keyword_linker.py
@@ -1,0 +1,161 @@
+import logging
+import re
+import xml.sax
+import xml.sax.handler
+import xml.sax.xmlreader
+import xml.sax.saxutils
+
+from pathlib import Path
+
+import click
+
+from fodt.constants import ClickOptions, Directories, FileNames, FileExtensions
+from fodt.exceptions import HandlerDoneException, ParsingException
+from fodt import helpers
+from fodt.xml_helpers import XMLHelper
+
+class ExtractURI_Handler(xml.sax.handler.ContentHandler):
+    def __init__(self, keyword_name: str) -> None:
+        self.keyword_name = keyword_name
+        self.in_section = False
+        self.in_bookmark = False
+        self.in_bookmark2 = False
+        self.uri = ""
+
+    def characters(self, content: str):
+        if self.in_bookmark2:
+            # Check if the content matches the keyword name
+            match =  re.search(self.keyword_name, content)
+            if match is None:
+                #self.uri = None
+                #raise ParsingException(
+                #    f"Keyword name {self.keyword_name} not found in bookmark content: {content}"
+                #)
+                # NOTE: Since the content may contain span tags, for example the CO2STORE keyword goes like this
+                #  <text:span text:style-name="T6">C</text:span>O2STORE
+                # we cannot expect to find the keyword name in the content. Instead we print a warning and
+                # the user can manually check the warning message to see if the keyword name was found.
+                logging.warning(f"Keyword name {self.keyword_name} not found in bookmark content: {content}")
+            raise HandlerDoneException("Done parsing.")
+
+    def endDocument(self):
+        raise ParsingException("Keyword name not found in document")
+
+    def endElement(self, name: str):
+        if name == "text:h":
+            if self.in_section:
+                self.in_section = False
+                raise ParsingException("Keyword name not found in document")
+        elif self.in_section and name == "text:bookmark-start":
+            if self.in_bookmark:
+                self.in_bookmark2 = True  # In the middle of a bookmark between start and end
+        elif self.in_section and name == "text:bookmark-end":
+            if self.in_bookmark:
+                self.in_bookmark = False
+                raise ParsingException("Keyword name not found in document")
+
+    def get_extracted_uri(self) -> str:
+        return self.uri
+
+    # This callback is used for debugging, it can be used to print
+    #  line numbers in the XML file
+    def setDocumentLocator(self, locator):
+        self.locator = locator
+
+    def startDocument(self):
+        pass
+
+    def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
+        if name == "text:h":
+            if "text:outline-level" in attrs.getNames():
+                level = attrs.getValue("text:outline-level")
+                if level == "3":
+                    self.in_section = True
+        elif self.in_section and name == "text:bookmark-start":
+            self.in_bookmark = True
+            # Assume there always will be a text:bookmark-start tag immediately
+            # following the text:h tag. This element will contain the keyword name.
+            self.uri = attrs.getValue("text:name")
+
+
+class ExtractURI:
+    def __init__(self, file: Path, keyword_name: str) -> None:
+        self.filename = file
+        self.keyword_name = keyword_name
+
+    def extract(self) -> str:
+        parser = xml.sax.make_parser()
+        handler = ExtractURI_Handler(self.keyword_name)
+        parser.setContentHandler(handler)
+        try:
+            parser.parse(str(self.filename))
+        except HandlerDoneException as e:
+            pass
+        uri = handler.get_extracted_uri()
+        return uri
+
+class ProcessChapter:
+    def __init__(self, maindir: Path, chapter: str, section: str, kw_file: Path, kw_uri_map: dict[str, str]) -> None:
+        self.chapter = chapter
+        self.section = section
+        self.kw_file = kw_file
+        self.kw_uri_map = kw_uri_map
+        self.maindir = maindir
+
+    def process(self) -> None:
+        with open(self.kw_file, "r", encoding='utf8') as f:
+            for line in f:
+                keyword = line.strip()
+                uri = self.keyword_uri(keyword)
+                self.kw_uri_map[keyword] = uri
+
+    def keyword_uri(self, keyword: str) -> str:
+        kw_file = (self.maindir / Directories.chapters / Directories.subsections / 
+                   f"{self.chapter}.{self.section}" / f"{keyword}.{FileExtensions.fodt}")
+        uri = ExtractURI(kw_file, keyword).extract()
+        return uri
+
+# fodt-gen-kw-uri-map
+# -------------------
+#
+# SHELL USAGE:
+#
+# fodt-gen-kw-uri-map --maindir=<main_dir> --keyword_dir=<keyword_dir>
+#
+# DESCRIPTION:
+#
+#   Generates a map: KW_NAME -> URI for all keywords. The map is saved to the file
+#   "meta/kw_uri_map.txt" in the main directory.
+#
+# EXAMPLE:
+#
+#  fodt-gen-kw-uri-map
+#
+#  Will use the default values: --maindir=../../parts --keyword_dir=../../keyword-names
+#
+@click.command()
+@ClickOptions.maindir()
+@ClickOptions.keyword_dir
+def gen_kw_uri_map(maindir: str|None, keyword_dir: str|None) -> None:
+    logging.basicConfig(level=logging.INFO)
+    keyword_dir = helpers.get_keyword_dir(keyword_dir)
+    maindir = helpers.get_maindir(maindir)
+    kw_uri_map = {}
+    # Assume all directories in keyword_dir are keyword directories on the form xx.yy
+    # where xx is the chapter number and yy is the section number.
+    for item1 in keyword_dir.iterdir():
+        if not item1.is_dir():
+            continue
+        chapter_str = item1.name
+        (chapter, section) = chapter_str.split(".")
+        kw_file = item1 / FileNames.keywords
+        logging.info(f"Processing chapter {chapter_str}")
+        ProcessChapter(maindir, chapter, section, kw_file, kw_uri_map).process()
+
+    with open(maindir / Directories.meta / FileNames.kw_uri_map, "w", encoding='utf8') as f:
+        for kw in sorted(kw_uri_map.keys()):
+            f.write(f"{kw} {kw_uri_map[kw]}\n")
+    logging.info(f"Generated keyword URI map to {maindir / Directories.meta / FileNames.kw_uri_map}")
+
+if __name__ == "__main__":
+    gen_kw_uri_map()

--- a/scripts/python/src/fodt/remove_span_tags.py
+++ b/scripts/python/src/fodt/remove_span_tags.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import click
 
 from fodt.constants import ClickOptions
-from fodt.helpers import Helpers
+from fodt import helpers
 from fodt.xml_helpers import XMLHelper
 
 class RemoveEmptyLinesHandler(xml.sax.handler.ContentHandler):
@@ -354,10 +354,10 @@ def remove_version_span_tags(
     if filename is not None:
         filename = Path(filename)
         assert filename.is_absolute()
-        maindir, filename = Helpers.locate_maindir_and_filename(maindir, filename)
+        maindir, filename = helpers.locate_maindir_and_filename(maindir, filename)
     else:
         # Convert maindir to an absolute path
-        maindir = Helpers.get_maindir(maindir)
+        maindir = helpers.get_maindir(maindir)
         maindir = Path(maindir).absolute()
         assert maindir.is_dir()
     RemoveSpanTags(maindir, filename, max_files).remove_span_tags()

--- a/scripts/python/src/fodt/remove_subsections.py
+++ b/scripts/python/src/fodt/remove_subsections.py
@@ -11,7 +11,7 @@ from typing import Callable
 
 from fodt.xml_helpers import XMLHelper
 from fodt.exceptions import HandlerDoneException, InputException, ParsingException
-from fodt.helpers import Helpers
+from fodt import helpers
 
 class PartsHandler(xml.sax.handler.ContentHandler):
     def __init__(
@@ -150,7 +150,7 @@ class RemoveSubSections():
     ) -> None:
         logging.info(f"Removing parts from {filename}.")
         outputdir = Path(outputfn).parent
-        keywords = Helpers.read_keyword_order_v2(keyword_dir, chapter, section)
+        keywords = helpers.read_keyword_order_v2(keyword_dir, chapter, section)
         parser = xml.sax.make_parser()
         handler = PartsHandler(outputfn, chapter, section, keywords, replace_callback)
         parser.setContentHandler(handler)

--- a/scripts/python/src/fodt/set_fonts.py
+++ b/scripts/python/src/fodt/set_fonts.py
@@ -4,7 +4,7 @@ import click
 
 from pathlib import Path
 from fodt.constants import ClickOptions, Directories, TagEvent
-from fodt.helpers import Helpers
+from fodt import helpers
 from fodt.xml_helpers import XMLHelper
 import xml.sax
 import xml.sax.handler

--- a/scripts/python/src/fodt/split_subdocument.py
+++ b/scripts/python/src/fodt/split_subdocument.py
@@ -15,7 +15,7 @@ class Splitter():
         self.chapter = chapter
         self.section = section
         self.maindir = helpers.get_maindir(maindir)
-        self.keyword_dir = helpers.get_keyword_dir(keyword_dir, self.maindir)
+        self.keyword_dir = helpers.get_keyword_dir(keyword_dir)
         self.metadata_dir = self.maindir / Directories.meta
         assert self.maindir.is_dir()
 

--- a/scripts/python/src/fodt/split_subdocument.py
+++ b/scripts/python/src/fodt/split_subdocument.py
@@ -7,26 +7,26 @@ import fodt.string_functions
 from fodt.constants import ClickOptions, Directories, FileNames, FileExtensions
 from fodt.create_subdocument import CreateSubDocument2
 from fodt.extract_subsections import ExtractSubSections
-from fodt.helpers import Helpers
+from fodt import helpers
 from fodt.remove_subsections import RemoveSubSections
 
 class Splitter():
     def __init__(self, maindir: str, keyword_dir: str, chapter: int, section: int) -> None:
         self.chapter = chapter
         self.section = section
-        self.maindir = Helpers.get_maindir(maindir)
-        self.keyword_dir = Helpers.get_keyword_dir(keyword_dir, self.maindir)
+        self.maindir = helpers.get_maindir(maindir)
+        self.keyword_dir = helpers.get_keyword_dir(keyword_dir, self.maindir)
         self.metadata_dir = self.maindir / Directories.meta
         assert self.maindir.is_dir()
 
     def create_backup_main_document(self) -> None:
-        self.source_file = Helpers.create_backup_document(self.filename)
+        self.source_file = helpers.create_backup_document(self.filename)
 
     def create_main_document(self) -> None:
         logging.info(f"Creating main document in {self.outputdir}.")
         self.destfile = self.outputdir / self.filename.name
         self.create_backup_main_document()
-        replace_callback = Helpers.replace_section_callback
+        replace_callback = helpers.replace_section_callback
         remover = RemoveSubSections(
             self.source_file,
             self.destfile,

--- a/scripts/python/src/fodt/validate_automatic_styles.py
+++ b/scripts/python/src/fodt/validate_automatic_styles.py
@@ -9,7 +9,7 @@ import click
 
 from fodt.constants import ClickOptions
 from fodt.exceptions import HandlerDoneException
-from fodt.helpers import Helpers
+from fodt import helpers
 from fodt.xml_handlers import GetUsedStylesHandler
 
 class GetDefinedStylesHandler(xml.sax.handler.ContentHandler):
@@ -158,9 +158,9 @@ def validate(ctx: click.Context, maindir: str, quiet: bool) -> None:
 @click.argument("keyword", type=str, required=True)
 @click.pass_context
 def subsection(ctx: click.Context, section: str, keyword: str) -> None:
-    (chapter, section) = Helpers.split_section(section)
+    (chapter, section) = helpers.split_section(section)
     maindir = ctx.obj["MAIN_DIR"]
-    filename = Helpers.keyword_fodt_file_path(maindir, chapter, section, keyword)
+    filename = helpers.keyword_fodt_file_path(maindir, chapter, section, keyword)
     Validator(filename).validate()
 
 
@@ -169,7 +169,7 @@ def subsection(ctx: click.Context, section: str, keyword: str) -> None:
 @click.pass_context
 def chapter(ctx: click.Context, chapter: str) -> None:
     maindir = ctx.obj["MAIN_DIR"]
-    filename = Helpers.chapter_fodt_file_path(maindir, chapter)
+    filename = helpers.chapter_fodt_file_path(maindir, chapter)
     Validator(filename).validate()
 
 

--- a/scripts/python/tests/test_helpers.py
+++ b/scripts/python/tests/test_helpers.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 from fodt.constants import Directories, FileNames
-from fodt.helpers import Helpers
+from fodt import helpers
 
 class TestLocateMainDirAndFilename:
     def test_locate_with_absolute_path_exists(self, tmp_path: Path) -> None:
@@ -16,7 +16,7 @@ class TestLocateMainDirAndFilename:
         filename_dir.mkdir()
         filename = filename_dir / "1.fodt"
         filename.touch()
-        result_maindir, result_filename = Helpers.locate_maindir_and_filename(
+        result_maindir, result_filename = helpers.locate_maindir_and_filename(
             str(maindir), str(filename)
         )
         assert result_maindir == maindir
@@ -34,7 +34,7 @@ class TestLocateMainDirAndFilename:
         filename = filename_dir / "1.fodt"
         filename.touch()
         with pytest.raises(FileNotFoundError) as excinfo:
-            Helpers.locate_maindir_and_filename(
+            helpers.locate_maindir_and_filename(
                 str(maindir), str(filename)
             )
         assert (f"Could not find '{FileNames.main_document}' in a directory "
@@ -55,7 +55,7 @@ class TestLocateMainDirAndFilename:
         filename_path = filename_dir / filename
         filename_path.touch()  # Create the file within maindir
         filename_abs_path = maindir / filename_path
-        result_maindir, result_filename = Helpers.locate_maindir_and_filename(
+        result_maindir, result_filename = helpers.locate_maindir_and_filename(
             str(maindir), str(filename_path)
         )
         assert result_maindir == maindir
@@ -75,7 +75,7 @@ class TestLocateMainDirAndFilename:
         filename_path.touch()  # Create the file in CWD
         maindir = tmp_path  # Some dummy path that is not the maindir
         with pytest.raises(FileNotFoundError) as excinfo:
-            Helpers.locate_maindir_and_filename(
+            helpers.locate_maindir_and_filename(
                 str(maindir), str(filename_path)
             )
         assert excinfo.match(
@@ -94,7 +94,7 @@ class TestLocateMainDirAndFilename:
         # Do not create the file, simulating a non-existent file scenario
 
         with pytest.raises(AssertionError):
-            Helpers.locate_maindir_and_filename(
+            helpers.locate_maindir_and_filename(
                 str(maindir), str(filename)
             )
 
@@ -107,7 +107,7 @@ class TestLocateMainDirFromCwd:
         mainfile = maindir / FileNames.main_document
         mainfile.touch()
         os.chdir(str(tmp_path))
-        result = Helpers.locate_maindir_from_current_dir()
+        result = helpers.locate_maindir_from_current_dir()
         assert result == maindir
 
     def test_locate_exists_as_parent(self, tmp_path: Path):
@@ -118,7 +118,7 @@ class TestLocateMainDirFromCwd:
         mainfile = maindir / FileNames.main_document
         mainfile.touch()
         os.chdir(str(maindir))
-        result = Helpers.locate_maindir_from_current_dir()
+        result = helpers.locate_maindir_from_current_dir()
         assert result == maindir
 
     def test_locate_exists_as_sibling_of_parent(self, tmp_path: Path):
@@ -132,5 +132,5 @@ class TestLocateMainDirFromCwd:
         subdir = tmp_path / "subdir"
         subdir.mkdir()
         os.chdir(str(subdir))
-        result = Helpers.locate_maindir_from_current_dir()
+        result = helpers.locate_maindir_from_current_dir()
         assert result == maindir


### PR DESCRIPTION
This script can be used to extract a mapping from keyword names to XML URI tag names. The mapping can be saved to a file and later be used to make keywords clickable. So the goal is to enable the user to click on a keyword referenced in a paragraph of text in the manual, and then automatically jump to the page where that keyword is defined.

The plan is to use the produced mapping in another script (yet to be written) that will convert keyword names into `<text:a xlink:href="some_uri" ...>KEYWORD_NAME</text:a>` which will make the text KEYWORD_NAME into a clickable link.