### PR TITLE
Update link keywords script: Do not link keywords followed by a dash

### DIFF
--- a/scripts/python/src/fodt/keyword_linker.py
+++ b/scripts/python/src/fodt/keyword_linker.py
@@ -58,7 +58,8 @@ class FileHandler(xml.sax.handler.ContentHandler):
                 ) +
             # NOTE: We cannot use \b here because if the keyword ends with "-" the word boundary
             #  \b will not match between a space and a hyphen. Instead we use a negative lookahead
-            r')(?!\w)(?!&apos;)' # Negative lookaheads: no word char or &apos; after the keyword
+            # Negative lookaheads: no word char, "-" or &apos; after the keyword
+            r')(?![\w-])(?!&apos;)'
         )
         return pattern
 


### PR DESCRIPTION
Do not link keywords like "LGR" in the string "LGR-OPM1". See https://github.com/OPM/opm-reference-manual/pull/435#discussion_r1888930577 for more information