### PR TITLE
Remove class XMLHelpers from the Python scripts

### DIFF
--- a/scripts/python/src/fodt/add_keyword.py
+++ b/scripts/python/src/fodt/add_keyword.py
@@ -16,7 +16,7 @@ from fodt.create_subdocument import CreateSubDocument3
 from fodt import helpers
 from fodt.remove_subsections import RemoveSubSections
 from fodt.templates import Templates
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class AppendixHandler(xml.sax.handler.ContentHandler):
     def __init__(
@@ -57,11 +57,11 @@ class AppendixHandler(xml.sax.handler.ContentHandler):
     def characters(self, content: str):
         if self.in_styles:
             self.maybe_close_start_tag(self.content)
-            self.content.write(XMLHelper.escape(content))
+            self.content.write(xml_helpers.escape(content))
         elif self.in_appendix_table:
             if self.in_table_row:
                 self.maybe_close_start_tag(self.current_row)
-                self.current_row.write(XMLHelper.escape(content))
+                self.current_row.write(xml_helpers.escape(content))
             else:
                 if self.start_tag_open:
                     self.between_rows += ">"
@@ -80,7 +80,7 @@ class AppendixHandler(xml.sax.handler.ContentHandler):
                     if self.current_table_number == self.keyword_table_number:
                         self.found_appendix_table = True
             self.maybe_close_start_tag(self.content)
-            self.content.write(XMLHelper.escape(content))
+            self.content.write(xml_helpers.escape(content))
 
     def endElement(self, name: str):
         if name == "table:table-cell":
@@ -106,7 +106,7 @@ class AppendixHandler(xml.sax.handler.ContentHandler):
                     self.between_rows += "/>"
                     self.start_tag_open = False
                 else:
-                    self.between_rows += XMLHelper.endtag(name)
+                    self.between_rows += xml_helpers.endtag(name)
         else:
             if self.in_styles:
                 if name == "office:automatic-styles":
@@ -157,7 +157,7 @@ class AppendixHandler(xml.sax.handler.ContentHandler):
 
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if self.in_styles:
@@ -192,7 +192,7 @@ class AppendixHandler(xml.sax.handler.ContentHandler):
                     self.write_start_tag(self.current_row, name, attrs)
                 else:
                     self.start_tag_open = True
-                    self.between_rows += XMLHelper.starttag(name, attrs, close_tag=False)
+                    self.between_rows += xml_helpers.starttag(name, attrs, close_tag=False)
             else:
                 self.write_start_tag(self.content, name, attrs)
 
@@ -213,7 +213,7 @@ class AppendixHandler(xml.sax.handler.ContentHandler):
             buffer.write("/>")
             self.start_tag_open = False
         else:
-            buffer.write(XMLHelper.endtag(name))
+            buffer.write(xml_helpers.endtag(name))
 
     def write_missing_styles(self):
         for style_name in self.style_names:
@@ -226,7 +226,7 @@ class AppendixHandler(xml.sax.handler.ContentHandler):
         if self.start_tag_open:
             buffer.write(">")  # Close the start tag
         self.start_tag_open = True
-        buffer.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        buffer.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
 
 class AddKeyword():

--- a/scripts/python/src/fodt/add_keyword_status.py
+++ b/scripts/python/src/fodt/add_keyword_status.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import click
 
 from fodt.constants import ClickOptions, Directories, FileExtensions, KeywordStatus, Regex
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class AppendixKeywordHandler(xml.sax.handler.ContentHandler):
     def __init__(self, keyword: str, status: KeywordStatus, opm_flow: bool) -> None:
@@ -55,7 +55,7 @@ class AppendixKeywordHandler(xml.sax.handler.ContentHandler):
             self.current_keyword = None
             self.in_table_cell_p = False
             self.found_table_cell = False
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def collect_table_cell_styles(self, attrs: xml.sax.xmlreader.AttributesImpl) -> None:
         # collect the style names for orange and green colors
@@ -92,12 +92,12 @@ class AppendixKeywordHandler(xml.sax.handler.ContentHandler):
             self.found_table_cell = False
             if self.opm_flow:
                 content = "OPM Flow"
-                self.content.write(XMLHelper.escape(content))
+                self.content.write(xml_helpers.escape(content))
         if self.start_tag_open:
             self.content.write("/>")
             self.start_tag_open = False
         else:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def get_content(self) -> str:
         return self.content.getvalue()
@@ -159,7 +159,7 @@ class AppendixKeywordHandler(xml.sax.handler.ContentHandler):
 
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if self.start_tag_open:
@@ -181,7 +181,7 @@ class AppendixKeywordHandler(xml.sax.handler.ContentHandler):
             else:
                 attrs = self.handle_table_row(name, attrs)
         self.start_tag_open = True
-        self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
 
 class UpdateKeywordStatus:

--- a/scripts/python/src/fodt/automatic_styles_filter.py
+++ b/scripts/python/src/fodt/automatic_styles_filter.py
@@ -8,7 +8,7 @@ import xml.sax.saxutils
 
 from pathlib import Path
 from fodt.constants import AutomaticStyles, FileExtensions, FileNames
-from fodt.xml_helpers import XMLHelper
+from fodt.xml_helpers import xml_helper
 
 class ElementHandler(xml.sax.handler.ContentHandler):
     def __init__(self, styles: set[str]) -> None:
@@ -39,7 +39,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
                 # one of these attributes.
                 self.include = True
         if self.include:
-            self.content.write(XMLHelper.starttag(name, attrs))
+            self.content.write(xml_helpers.starttag(name, attrs))
 
     def endElement(self, name: str):
         if self.nesting == 0:
@@ -48,11 +48,11 @@ class ElementHandler(xml.sax.handler.ContentHandler):
             if self.nesting >= 1:
                 self.nesting -= 1
         if self.include:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def characters(self, content: str):
         if self.include:
-            self.content.write(XMLHelper.escape(content))
+            self.content.write(xml_helpers.escape(content))
 
 
 class AutomaticStylesFilter:

--- a/scripts/python/src/fodt/check_links_office_binary.py
+++ b/scripts/python/src/fodt/check_links_office_binary.py
@@ -12,7 +12,7 @@ import click
 from fodt.constants import ClickOptions, Directories, FileExtensions
 from fodt.exceptions import HandlerDoneException
 from fodt import helpers
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class FileHandler(xml.sax.handler.ContentHandler):
     def __init__(self, keyword_name: str) -> None:
@@ -36,7 +36,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
             # We are inside an errouneous link, and we should actually not skip this content
             #  since it was part of the original binary data
             pass
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def endDocument(self):
         pass
@@ -54,7 +54,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
             self.content.write("/>")
             self.start_tag_open = False
         else:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def get_content(self) -> str:
         return self.content.getvalue()
@@ -68,7 +68,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
         self.locator = locator
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if self.start_tag_open:
@@ -83,7 +83,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
                 # Do not write the start tag
                 return
         self.start_tag_open = True
-        self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
 
 class CheckLinks:

--- a/scripts/python/src/fodt/create_subdocument.py
+++ b/scripts/python/src/fodt/create_subdocument.py
@@ -7,7 +7,7 @@ from fodt.automatic_styles_filter import AutomaticStylesFilter2, AutomaticStyles
 from fodt.constants import Directories, FileExtensions, FileNames, MetaSections
 from fodt.exceptions import InputException
 from fodt import helpers
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 from fodt.styles_filter import StylesFilter
 
 class CreateSubDocument():
@@ -73,7 +73,7 @@ class CreateSubDocument():
 """)
 
     def write_office_document_start_tag(self) -> None:
-        tag = XMLHelper.get_office_document_start_tag(self.metadir)
+        tag = xml_helpers.get_office_document_start_tag(self.metadir)
         self.outputfile.write(tag)
 
     def write_meta(self, part: str) -> None:
@@ -134,7 +134,7 @@ class CreateSubDocument():
 """)
 
     def write_xml_header(self) -> None:
-        self.outputfile.write(XMLHelper.header)
+        self.outputfile.write(xml_helpers.HEADER)
 
 class CreateSubDocument1(CreateSubDocument):
     def __init__(

--- a/scripts/python/src/fodt/extract_appendix.py
+++ b/scripts/python/src/fodt/extract_appendix.py
@@ -16,7 +16,7 @@ from fodt.constants import (
 )
 from fodt.automatic_styles_filter import AutomaticStylesFilter4
 from fodt.exceptions import HandlerDoneException
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class CreateAppendixFile():
     def __init__(self, maindir: str, appendix: str, appendix_txt: str, styles: set[str]) -> None:
@@ -66,7 +66,7 @@ class CreateAppendixFile():
 
     def write_office_document_start_tag(self) -> None:
         self.metadir = self.maindir / Directories.meta
-        tag = XMLHelper.get_office_document_start_tag(self.metadir)
+        tag = xml_helpers.get_office_document_start_tag(self.metadir)
         self.outputfile.write(tag)
 
     def write_meta(self) -> None:
@@ -85,7 +85,7 @@ class CreateAppendixFile():
         self.outputfile.write(content)
 
     def write_xml_header(self) -> None:
-        self.outputfile.write(XMLHelper.header)
+        self.outputfile.write(xml_helpers.HEADER)
 
     def write_xml_footer(self) -> None:
         self.outputfile.write("""
@@ -127,9 +127,9 @@ class ExtractAndRemoveHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if self.in_appendix:
-            self.appendix.write(XMLHelper.escape(content))
+            self.appendix.write(xml_helpers.escape(content))
         else:
-            self.doc.write(XMLHelper.escape(content))
+            self.doc.write(xml_helpers.escape(content))
 
     def collect_styles(self, attrs: xml.sax.xmlreader.AttributesImpl) -> None:
         for (key, value) in attrs.items():
@@ -138,9 +138,9 @@ class ExtractAndRemoveHandler(xml.sax.handler.ContentHandler):
 
     def endElement(self, name: str):
         if self.in_appendix:
-            self.appendix.write(XMLHelper.endtag(name))
+            self.appendix.write(xml_helpers.endtag(name))
         else:
-            self.doc.write(XMLHelper.endtag(name))
+            self.doc.write(xml_helpers.endtag(name))
 
     def get_appendix(self) -> str:
         return self.appendix.getvalue()
@@ -163,7 +163,7 @@ class ExtractAndRemoveHandler(xml.sax.handler.ContentHandler):
         )
 
     def startDocument(self):
-        self.doc.write(XMLHelper.header)
+        self.doc.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if (not self.in_appendix) and (name == "text:list"):
@@ -179,24 +179,24 @@ class ExtractAndRemoveHandler(xml.sax.handler.ContentHandler):
                     xml_id = attrs.getValue("xml:id")
                     if xml_id == self.end_id:
                         self.in_appendix = False
-                        self.doc.write(XMLHelper.starttag(name, attrs))
+                        self.doc.write(xml_helpers.starttag(name, attrs))
                         return
             elif (self.end_type == "section") and (name == "text:section"):
                 self.in_appendix = False
-                self.doc.write(XMLHelper.starttag(name, attrs))
+                self.doc.write(xml_helpers.starttag(name, attrs))
                 return
             elif (self.end_type == "end") and (name == "text:p"):
                 if "text:style-name" in attrs.getNames():
                     style_name = attrs.getValue("text:style-name")
                     if style_name == "ENDENDEND":
                         self.in_appendix = False
-                        self.doc.write(XMLHelper.starttag(name, attrs))
+                        self.doc.write(xml_helpers.starttag(name, attrs))
                         return
         if self.in_appendix:
-            self.appendix.write(XMLHelper.starttag(name, attrs))
+            self.appendix.write(xml_helpers.starttag(name, attrs))
             self.collect_styles(attrs)
         else:
-            self.doc.write(XMLHelper.starttag(name, attrs))
+            self.doc.write(xml_helpers.starttag(name, attrs))
 
 class ExtractAndRemoveAppendixFromMain:
     def __init__(self, main_file: Path, appendix_number: str) -> None:

--- a/scripts/python/src/fodt/extract_chapters.py
+++ b/scripts/python/src/fodt/extract_chapters.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from fodt.constants import AutomaticStyles, Directories, FileNames, FileExtensions
 from fodt.exceptions import HandlerDoneException, InputException
-from fodt.xml_helpers import XMLHelper
+from fodt.xml_helpers import xml_helper
 
 class ChapterHandler(xml.sax.handler.ContentHandler):
     def __init__(self, outputdir: str, chapters: list[int]) -> None:
@@ -29,7 +29,7 @@ class ChapterHandler(xml.sax.handler.ContentHandler):
         name:str,
         attrs: xml.sax.xmlreader.AttributesImpl,
     ) -> None:
-        self.section.write(XMLHelper.starttag(name, attrs))
+        self.section.write(xml_helpers.starttag(name, attrs))
 
     def collect_styles(self, attrs: xml.sax.xmlreader.AttributesImpl) -> None:
         for (key, value) in attrs.items():
@@ -66,11 +66,11 @@ class ChapterHandler(xml.sax.handler.ContentHandler):
 
     def endElement(self, name: str):
         if self.in_section:
-            self.section.write(XMLHelper.endtag(name))
+            self.section.write(xml_helpers.endtag(name))
 
     def characters(self, content: str):
         if self.in_section:
-            self.section.write(XMLHelper.escape(content))
+            self.section.write(xml_helpers.escape(content))
 
     def patch_chapter_12(self, path: Path) -> None:
         with open(path, "r", encoding='utf8') as f:

--- a/scripts/python/src/fodt/extract_fonts.py
+++ b/scripts/python/src/fodt/extract_fonts.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import click
 
 from fodt.exceptions import HandlerDoneException
-from fodt.xml_helpers import XMLHelper
+from fodt.xml_helpers import xml_helper
 
 class FontHandler(xml.sax.handler.ContentHandler):
     def __init__(self, save_dir: Path) -> None:
@@ -30,7 +30,7 @@ class FontHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if self.in_binary_data:
-            self.font_data.write(XMLHelper.escape(content))
+            self.font_data.write(xml_helpers.escape(content))
 
     def endElement(self, name: str):
         if self.in_binary_data and name == 'office:binary-data':

--- a/scripts/python/src/fodt/extract_metadata.py
+++ b/scripts/python/src/fodt/extract_metadata.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from fodt.constants import Directories, MetaSections, TagEvent
 from fodt.exceptions import HandlerDoneException
-from fodt.xml_helpers import XMLHelper
+from fodt.xml_helpers import xml_helper
 
 class SectionHandler(xml.sax.handler.ContentHandler):
     def __init__(self, outputdir: str) -> None:
@@ -51,7 +51,7 @@ class SectionHandler(xml.sax.handler.ContentHandler):
     ) -> None:
         self.add_previous_content(prev_content)
         self.section.write(f"{self.add_indent(new_file)}")
-        self.section.write(XMLHelper.starttag(name, attrs))
+        self.section.write(xml_helpers.starttag(name, attrs))
         self.indent += 1
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
@@ -81,7 +81,7 @@ class SectionHandler(xml.sax.handler.ContentHandler):
             if last_event == TagEvent.END:
                 if self.enable_indent:
                     self.section.write("\n" + (" " * self.indent))
-            self.section.write(XMLHelper.endtag(name))
+            self.section.write(xml_helpers.endtag(name))
         if name == self.current_section:
             self.in_section = False
             self.write_section_to_file()
@@ -91,7 +91,7 @@ class SectionHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if self.in_section:
-            self.content.write(XMLHelper.escape(content))
+            self.content.write(xml_helpers.escape(content))
 
     def write_section_to_file(self):
         filename = self.current_section.removeprefix("office:") + ".xml"

--- a/scripts/python/src/fodt/extract_section.py
+++ b/scripts/python/src/fodt/extract_section.py
@@ -15,7 +15,7 @@ from fodt.automatic_styles_filter import AutomaticStylesFilter4
 from fodt.exceptions import ParsingException
 from fodt import helpers
 from fodt.styles_filter import StylesFilter
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class CreateSectionFile():
     def __init__(
@@ -75,7 +75,7 @@ class CreateSectionFile():
 
     def write_office_document_start_tag(self) -> None:
         self.metadir = self.maindir / Directories.meta
-        tag = XMLHelper.get_office_document_start_tag(self.metadir)
+        tag = xml_helpers.get_office_document_start_tag(self.metadir)
         self.outputfile.write(tag)
 
     def write_meta(self) -> None:
@@ -97,7 +97,7 @@ class CreateSectionFile():
         self.outputfile.write(content)
 
     def write_xml_header(self) -> None:
-        self.outputfile.write(XMLHelper.header)
+        self.outputfile.write(xml_helpers.HEADER)
 
     def write_xml_footer(self) -> None:
         self.outputfile.write("""
@@ -121,9 +121,9 @@ class ExtractAndRemoveHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if self.in_section:
-            self.section.write(XMLHelper.escape(content))
+            self.section.write(xml_helpers.escape(content))
         else:
-            self.doc.write(XMLHelper.escape(content))
+            self.doc.write(xml_helpers.escape(content))
 
     def collect_styles(self, attrs: xml.sax.xmlreader.AttributesImpl) -> None:
         for (key, value) in attrs.items():
@@ -137,9 +137,9 @@ class ExtractAndRemoveHandler(xml.sax.handler.ContentHandler):
 
     def endElement(self, name: str):
         if self.in_section:
-            self.section.write(XMLHelper.endtag(name))
+            self.section.write(xml_helpers.endtag(name))
         else:
-            self.doc.write(XMLHelper.endtag(name))
+            self.doc.write(xml_helpers.endtag(name))
 
     def get_section(self) -> str:
         return self.section.getvalue()
@@ -163,7 +163,7 @@ class ExtractAndRemoveHandler(xml.sax.handler.ContentHandler):
         )
 
     def startDocument(self):
-        self.doc.write(XMLHelper.header)
+        self.doc.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         # TODO: Looking for <text:h text:outline-level="2"> does not work for the last
@@ -176,17 +176,17 @@ class ExtractAndRemoveHandler(xml.sax.handler.ContentHandler):
                     if self.in_section:
                         self.in_section = False
                         self.done_extracting = True
-                        self.doc.write(XMLHelper.starttag(name, attrs))
+                        self.doc.write(xml_helpers.starttag(name, attrs))
                         return
                     elif self.current_section_number == self.section_number:
                         self.in_section = True
                         self.section = io.StringIO()
                         self.insert_section_link_into_doc()
         if self.in_section:
-            self.section.write(XMLHelper.starttag(name, attrs))
+            self.section.write(xml_helpers.starttag(name, attrs))
             self.collect_styles(attrs)
         else:
-            self.doc.write(XMLHelper.starttag(name, attrs))
+            self.doc.write(xml_helpers.starttag(name, attrs))
 
 
 

--- a/scripts/python/src/fodt/extract_subsections.py
+++ b/scripts/python/src/fodt/extract_subsections.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from fodt.constants import AutomaticStyles, Directories, FileNames, FileExtensions
 from fodt.exceptions import HandlerDoneException, InputException, ParsingException
 from fodt import helpers
-from fodt.xml_helpers import XMLHelper
+from fodt.xml_helpers import xml_helper
 
 class PartsHandler(xml.sax.handler.ContentHandler):
     def __init__(self, outputdir: Path, chapter: int, section: int,
@@ -37,7 +37,7 @@ class PartsHandler(xml.sax.handler.ContentHandler):
         name:str,
         attrs: xml.sax.xmlreader.AttributesImpl,
     ) -> None:
-        self.subsection.write(XMLHelper.starttag(name, attrs))
+        self.subsection.write(xml_helpers.starttag(name, attrs))
 
     def characters(self, content: str):
         if self.save_keyword_name:
@@ -62,7 +62,7 @@ class PartsHandler(xml.sax.handler.ContentHandler):
                 self.keyword_name = self.predefined_keywords[self.current_subsection - 1]
             self.save_keyword_name = False
         if self.in_subsection:
-            self.subsection.write(XMLHelper.escape(content))
+            self.subsection.write(xml_helpers.escape(content))
 
     def collect_styles(self, attrs: xml.sax.xmlreader.AttributesImpl) -> None:
         for (key, value) in attrs.items():
@@ -78,7 +78,7 @@ class PartsHandler(xml.sax.handler.ContentHandler):
             self.in_bookmark = False
             self.save_keyword_name = True
         if self.in_subsection:
-            self.subsection.write(XMLHelper.endtag(name))
+            self.subsection.write(xml_helpers.endtag(name))
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         done = False

--- a/scripts/python/src/fodt/extract_tag_attrs.py
+++ b/scripts/python/src/fodt/extract_tag_attrs.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from fodt.constants import Directories, FileNames
 from fodt.exceptions import HandlerDoneException
-from fodt.xml_helpers import XMLHelper
+from fodt.xml_helpers import xml_helper
 
 class TagHandler(xml.sax.handler.ContentHandler):
     def __init__(self, tag_name: str) -> None:
@@ -54,6 +54,6 @@ class ExtractDocAttrs():
                 f"will overwrite...")
         with open(filename, "w", encoding='utf-8') as f:
             for (key, value) in attrs.items():
-                evalue = XMLHelper.escape(value)
+                evalue = xml_helpers.escape(value)
                 f.write(f'{key}="{evalue}"\n')
         logging.info(f"Wrote document attributes to {filename}.")

--- a/scripts/python/src/fodt/extract_xml_tag.py
+++ b/scripts/python/src/fodt/extract_xml_tag.py
@@ -7,7 +7,7 @@ import xml.sax.saxutils
 
 from fodt.constants import TagEvent
 from fodt.exceptions import HandlerDoneException
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 
 class SectionHandler(xml.sax.handler.ContentHandler):
@@ -30,7 +30,7 @@ class SectionHandler(xml.sax.handler.ContentHandler):
         if self.enable_indent:
             self.remove_trailing_spaces()
         self.section += f"{self.add_indent()}"
-        self.section += XMLHelper.starttag(name, attrs)
+        self.section += xml_helpers.starttag(name, attrs)
         self.indent += 1
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
@@ -53,14 +53,14 @@ class SectionHandler(xml.sax.handler.ContentHandler):
                 self.remove_trailing_spaces()
                 if last_event == TagEvent.END:
                     self.section += "\n" + (" " * self.indent)
-            self.section += XMLHelper.endtag(name)
+            self.section += xml_helpers.endtag(name)
         if name == self.section_name:
             self.in_section = False
             raise HandlerDoneException(f"Done extracting sections {self.section_name}.")
 
     def characters(self, content: str):
         if self.in_section:
-            self.section += XMLHelper.escape(content)
+            self.section += xml_helpers.escape(content)
 
     def remove_trailing_spaces(self):
         self.section = re.sub(r"\s+$", "", self.section)

--- a/scripts/python/src/fodt/fix_footer_style.py
+++ b/scripts/python/src/fodt/fix_footer_style.py
@@ -8,7 +8,7 @@ import xml.sax.saxutils
 from pathlib import Path
 
 from fodt.constants import ClickOptions
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class ContentHandler(xml.sax.handler.ContentHandler):
     def __init__(self) -> None:
@@ -37,7 +37,7 @@ class ContentHandler(xml.sax.handler.ContentHandler):
                     )
                     self.fixed_style = True
                     return
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def endElement(self, name: str):
         if self.in_p_tag and name == "text:p":
@@ -53,7 +53,7 @@ class ContentHandler(xml.sax.handler.ContentHandler):
             self.content.write("/>")
             self.start_tag_open = False
         else:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def fixed_footer_style(self) -> bool:
         return self.fixed_style
@@ -62,7 +62,7 @@ class ContentHandler(xml.sax.handler.ContentHandler):
         return self.content.getvalue()
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if self.start_tag_open:
@@ -81,7 +81,7 @@ class ContentHandler(xml.sax.handler.ContentHandler):
             if attrs.getValue("style:name") == "_40_DocumentKeywordPageStyle":
                 self.in_master_page = True
         self.start_tag_open = True
-        self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
 
 class FixFooterStyle:

--- a/scripts/python/src/fodt/fix_letter_k_footer.py
+++ b/scripts/python/src/fodt/fix_letter_k_footer.py
@@ -8,7 +8,7 @@ import xml.sax.saxutils
 from pathlib import Path
 
 from fodt.constants import ClickOptions
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class ContentHandler(xml.sax.handler.ContentHandler):
     def __init__(self) -> None:
@@ -34,7 +34,7 @@ class ContentHandler(xml.sax.handler.ContentHandler):
                 self.content.write("K")
                 self.fixed_letter = True
                 return
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def endElement(self, name: str):
         if self.in_p_tag and name == "text:p":
@@ -49,7 +49,7 @@ class ContentHandler(xml.sax.handler.ContentHandler):
             self.content.write("/>")
             self.start_tag_open = False
         else:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def fixed_letter_k(self) -> bool:
         return self.fixed_letter
@@ -58,7 +58,7 @@ class ContentHandler(xml.sax.handler.ContentHandler):
         return self.content.getvalue()
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if self.start_tag_open:
@@ -74,7 +74,7 @@ class ContentHandler(xml.sax.handler.ContentHandler):
             if attrs.getValue("style:name") == "_40_DocumentKeywordPageStyle":
                 self.in_master_page = True
         self.start_tag_open = True
-        self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
 
 class FixLetterK:

--- a/scripts/python/src/fodt/fix_span_not_kw.py
+++ b/scripts/python/src/fodt/fix_span_not_kw.py
@@ -11,7 +11,7 @@ import click
 from fodt.constants import ClickOptions, FileExtensions, Directories
 from fodt.exceptions import HandlerDoneException
 from fodt import helpers
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 
 class FileHandler(xml.sax.handler.ContentHandler):
@@ -36,7 +36,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
             # tag and the end tag. If there is no content, characters() is not called.
             self.content.write(">")
             self.start_tag_open = False
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def endElement(self, name: str):
         if name == "office:styles":
@@ -46,7 +46,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
                     """ <style:style style:name="NotKeyword" style:family="text"/>\n """
                 )
             self.in_office_styles = False
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
             return
         elif name == "office:body":
             self.in_body = False
@@ -54,7 +54,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
             self.content.write("/>")
             self.start_tag_open = False
         else:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def file_changed(self) -> bool:
         return self._file_changed
@@ -74,7 +74,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
         self.locator = locator
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if self.start_tag_open:
@@ -99,7 +99,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
             if attrs.get("style:name") == "NotKeyword":
                 self.found_not_kw_style = True
         self.start_tag_open = True
-        self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
 
 class FixSpanNotKw:

--- a/scripts/python/src/fodt/helpers.py
+++ b/scripts/python/src/fodt/helpers.py
@@ -4,7 +4,7 @@ import shutil
 from pathlib import Path
 from fodt.constants import Directories, FileExtensions, FileNames
 from fodt.exceptions import InputException
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 def chapter_fodt_file_path(
     outputdir: str,
@@ -217,7 +217,7 @@ def read_keyword_template() -> str:
 def replace_section_callback(part: str, keyword: str) -> str:
     section = ".".join(part.split(".")[:2])
     href = f"{Directories.subsections}/{section}/{keyword}.fodt"
-    href = XMLHelper.escape(href)
+    href = xml_helpers.escape(href)
     return (f"""<text:section text:style-name="Sect1" text:name="Section{section}:{keyword}" """
                f"""text:protected="true">\n"""
             f"""     <text:section-source xlink:href="{href}" """

--- a/scripts/python/src/fodt/keyword_linker.py
+++ b/scripts/python/src/fodt/keyword_linker.py
@@ -14,7 +14,7 @@ import click
 from fodt.constants import ClickOptions, Directories, FileNames, FileExtensions
 from fodt.exceptions import HandlerDoneException, ParsingException
 from fodt import helpers, keyword_uri_map_generator
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class FileType(enum.Enum):
     CHAPTER = 1
@@ -124,7 +124,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
             self.content.write("/>")
             self.start_tag_open = False
         else:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def get_content(self) -> str:
         return self.content.getvalue()
@@ -141,7 +141,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
         if len(self.char_buf) > 0:
             # NOTE: We need to escape the content before we apply the regex pattern
             #  because it may insert tags (<text:a ...>) that should not be escaped.
-            characters = XMLHelper.escape(self.char_buf)
+            characters = xml_helpers.escape(self.char_buf)
             if self.office_body_found:
                 if (self.in_p
                     and (not self.in_a)
@@ -170,7 +170,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
         self.locator = locator
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         self.maybe_write_characters()
@@ -209,7 +209,7 @@ class FileHandler(xml.sax.handler.ContentHandler):
                 self.in_draw_frame = True
                 self.in_draw_recursion += 1
         self.start_tag_open = True
-        self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
     def update_example_stack(self, attrs: xml.sax.xmlreader.AttributesImpl) -> None:
         if "text:style-name" in attrs.getNames():

--- a/scripts/python/src/fodt/keyword_uri_map_generator.py
+++ b/scripts/python/src/fodt/keyword_uri_map_generator.py
@@ -12,7 +12,7 @@ import click
 from fodt.constants import ClickOptions, Directories, FileNames, FileExtensions
 from fodt.exceptions import HandlerDoneException, ParsingException
 from fodt import helpers
-from fodt.xml_helpers import XMLHelper
+from fodt.xml_helpers import xml_helper
 
 class ExtractURI_Handler(xml.sax.handler.ContentHandler):
     def __init__(self, keyword_name: str) -> None:

--- a/scripts/python/src/fodt/remove_bookmarks.py
+++ b/scripts/python/src/fodt/remove_bookmarks.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import click
 
 from fodt.constants import ClickOptions
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class ElementHandler(xml.sax.handler.ContentHandler):
     # Find the master-styles section and remove all bookmark refs from it.
@@ -30,7 +30,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
             # tag and the end tag. If there is no content, characters() is not called.
             self.content.write(">")
             self.start_tag_open = False
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def endElement(self, name: str):
         if self.in_master_styles:
@@ -43,13 +43,13 @@ class ElementHandler(xml.sax.handler.ContentHandler):
             self.content.write("/>")
             self.start_tag_open = False
         else:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def get_content(self) -> str:
         return self.content.getvalue()
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         # logging.info(f"startElement: {name}")
@@ -61,7 +61,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
         if self.start_tag_open:
             self.content.write(">")
         self.start_tag_open = True
-        self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
 class RemoveBookmarksFromMasterStyles():
     def __init__(self, maindir: str, filename: str|None, directory: str|None) -> None:

--- a/scripts/python/src/fodt/remove_chapters.py
+++ b/scripts/python/src/fodt/remove_chapters.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Callable
 
 from fodt.exceptions import HandlerDoneException, InputException
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class ChapterHandler(xml.sax.handler.ContentHandler):
     def __init__(
@@ -35,14 +35,14 @@ class ChapterHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if not self.in_section:
-            self.content.write(XMLHelper.escape(content))
+            self.content.write(xml_helpers.escape(content))
 
     def default_replace_callback(self, section: int) -> str:
         return f"<text:section>Section{section}</text:section>\n"
 
     def endElement(self, name: str):
         if not self.in_section:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def endDocument(self) -> None:
         self.write_file()
@@ -71,7 +71,7 @@ class ChapterHandler(xml.sax.handler.ContentHandler):
                         else:
                             self.in_section = False
         if not self.in_section:
-            self.content.write(XMLHelper.starttag(name, attrs))
+            self.content.write(xml_helpers.starttag(name, attrs))
 
     def start_of_appendix(self, name: str, attrs: xml.sax.xmlreader.AttributesImpl) -> bool:
         if name == "text:list":
@@ -92,7 +92,7 @@ class ChapterHandler(xml.sax.handler.ContentHandler):
         logging.info(f"Wrote modified file to file {filename}.")
 
     def write_xml_header(self) -> None:
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
 class RemoveChapters():
     def __init__(

--- a/scripts/python/src/fodt/remove_elements.py
+++ b/scripts/python/src/fodt/remove_elements.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from fodt.constants import TagEvent
 from fodt.exceptions import HandlerDoneException
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class ElementHandler(xml.sax.handler.ContentHandler):
     def __init__(self, outputfn: str, count: int, name: str) -> None:
@@ -43,11 +43,11 @@ class ElementHandler(xml.sax.handler.ContentHandler):
             else:
                 self.nesting += 1
         if self.done_removing or (not self.in_element):
-            self.content.write(XMLHelper.starttag(name, attrs))
+            self.content.write(xml_helpers.starttag(name, attrs))
 
     def endElement(self, name: str):
         if not self.in_element:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
         else:
             if name == self.tag_name:
                 self.nesting -= 1
@@ -63,7 +63,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
 
     def characters(self, content: str):
         if not self.in_element:
-            self.content.write(XMLHelper.escape(content))
+            self.content.write(xml_helpers.escape(content))
 
     def write_file(self):
         filename = Path(self.outputfn)
@@ -75,7 +75,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
         logging.info(f"Wrote modified file to file {filename}.")
 
     def write_xml_header(self) -> None:
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
 class RemoveElements():
     def __init__(self, name: str, outputfn: str, filename: str, count: int) -> None:

--- a/scripts/python/src/fodt/remove_fonts.py
+++ b/scripts/python/src/fodt/remove_fonts.py
@@ -13,7 +13,7 @@ import click
 
 from fodt.constants import ClickOptions
 from fodt.exceptions import HandlerDoneException
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class FontHandler(xml.sax.handler.ContentHandler):
     def __init__(self) -> None:
@@ -24,7 +24,7 @@ class FontHandler(xml.sax.handler.ContentHandler):
     def characters(self, content: str):
         if self.in_font_face:
             return  # we remove the interior of a font-face tag
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def endElement(self, name: str):
         if name == 'office:font-face-decls':
@@ -34,10 +34,10 @@ class FontHandler(xml.sax.handler.ContentHandler):
         else:
             if self.in_font_face:
                 return  # we remove the interior of a font-face tag
-        self.content.write(XMLHelper.endtag(name))
+        self.content.write(xml_helpers.endtag(name))
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if name == 'office:font-face-decls':
@@ -47,7 +47,7 @@ class FontHandler(xml.sax.handler.ContentHandler):
                 self.in_font_face = True
             elif self.in_font_face:
                 return  # we remove the interior of a font-face tag
-        self.content.write(XMLHelper.starttag(name, attrs))
+        self.content.write(xml_helpers.starttag(name, attrs))
 
 
 class RemoveFontData:

--- a/scripts/python/src/fodt/remove_span_tags.py
+++ b/scripts/python/src/fodt/remove_span_tags.py
@@ -10,7 +10,7 @@ import click
 
 from fodt.constants import ClickOptions
 from fodt import helpers
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class RemoveEmptyLinesHandler(xml.sax.handler.ContentHandler):
     # Within the office:automatic-styles section, remove empty lines left behind
@@ -42,7 +42,7 @@ class RemoveEmptyLinesHandler(xml.sax.handler.ContentHandler):
             # tag and the end tag. If there is no content, characters() is not called.
             self.content.write(">")
             self.start_tag_open = False
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def endElement(self, name: str):
         if self.in_auto_styles:
@@ -57,7 +57,7 @@ class RemoveEmptyLinesHandler(xml.sax.handler.ContentHandler):
             self.content.write("/>")
             self.start_tag_open = False
         else:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def get_content(self) -> str:
         return self.content.getvalue()
@@ -68,7 +68,7 @@ class RemoveEmptyLinesHandler(xml.sax.handler.ContentHandler):
         self.locator = locator
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if self.start_tag_open:
@@ -89,7 +89,7 @@ class RemoveEmptyLinesHandler(xml.sax.handler.ContentHandler):
             self.in_tag = True
             self.tag_recursion += 1
         self.start_tag_open = True
-        self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
 
 class RemoveStylesHandler(xml.sax.handler.ContentHandler):
@@ -113,7 +113,7 @@ class RemoveStylesHandler(xml.sax.handler.ContentHandler):
             # tag and the end tag. If there is no content, characters() is not called.
             self.content.write(">")
             self.start_tag_open = False
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def endElement(self, name: str):
         if self.in_style:
@@ -126,13 +126,13 @@ class RemoveStylesHandler(xml.sax.handler.ContentHandler):
             self.content.write("/>")
             self.start_tag_open = False
         else:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def get_content(self) -> str:
         return self.content.getvalue()
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if self.in_style:
@@ -149,7 +149,7 @@ class RemoveStylesHandler(xml.sax.handler.ContentHandler):
                     self.in_style = True
                     return # remove this tag
         self.start_tag_open = True
-        self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
 
 class RemoveSpanHandler(xml.sax.handler.ContentHandler):
@@ -179,7 +179,7 @@ class RemoveSpanHandler(xml.sax.handler.ContentHandler):
             # tag and the end tag. If there is no content, characters() is not called.
             self.content.write(">")
             self.start_tag_open = False
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def endElement(self, name: str):
         if name == "office:automatic-styles":
@@ -198,7 +198,7 @@ class RemoveSpanHandler(xml.sax.handler.ContentHandler):
             self.content.write("/>")
             self.start_tag_open = False
         else:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def get_content(self) -> str:
         return self.content.getvalue()
@@ -218,7 +218,7 @@ class RemoveSpanHandler(xml.sax.handler.ContentHandler):
         self.locator = locator
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if self.start_tag_open:
@@ -249,7 +249,7 @@ class RemoveSpanHandler(xml.sax.handler.ContentHandler):
                     #logging.info(f"removing span: {span_style_name}")
                     return  # remove this tag
         self.start_tag_open = True
-        self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
 
 class RemoveSpanTags:

--- a/scripts/python/src/fodt/remove_subsections.py
+++ b/scripts/python/src/fodt/remove_subsections.py
@@ -9,7 +9,7 @@ import xml.sax.saxutils
 from pathlib import Path
 from typing import Callable
 
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 from fodt.exceptions import HandlerDoneException, InputException, ParsingException
 from fodt import helpers
 
@@ -46,7 +46,7 @@ class PartsHandler(xml.sax.handler.ContentHandler):
             self.start_tag_open = False
         # if (not self.in_subsection) and (not self.remove_section):
         if not self.in_main_section:
-            self.content.write(XMLHelper.escape(content))
+            self.content.write(xml_helpers.escape(content))
 
     def check_included_section(self, name: str, attrs: xml.sax.xmlreader.AttributesImpl) -> bool:
         if "text:name" in attrs.getNames():
@@ -70,7 +70,7 @@ class PartsHandler(xml.sax.handler.ContentHandler):
                 self.content.write("/>")
                 self.start_tag_open = False
             else:
-                self.content.write(XMLHelper.endtag(name))
+                self.content.write(xml_helpers.endtag(name))
         if name == "text:section":
             if self.remove_section:
                 self.remove_section = False
@@ -125,7 +125,7 @@ class PartsHandler(xml.sax.handler.ContentHandler):
             self.content.write(callback(part, keyword))
         if (not self.in_subsection) and (not self.remove_section):
             self.start_tag_open = True
-            self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+            self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
     def write_file(self):
         filename = Path(self.outputfn)
@@ -135,7 +135,7 @@ class PartsHandler(xml.sax.handler.ContentHandler):
         logging.info(f"Wrote modified file to file {filename}.")
 
     def write_xml_header(self) -> None:
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
 
 class RemoveSubSections():

--- a/scripts/python/src/fodt/remove_undefined_spans.py
+++ b/scripts/python/src/fodt/remove_undefined_spans.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import click
 
 from fodt.constants import ClickOptions
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 
 class RemoveSpanHandler(xml.sax.handler.ContentHandler):
@@ -37,7 +37,7 @@ class RemoveSpanHandler(xml.sax.handler.ContentHandler):
             # tag and the end tag. If there is no content, characters() is not called.
             self.content.write(">")
             self.start_tag_open = False
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def endElement(self, name: str):
         if name == "office:body":
@@ -53,7 +53,7 @@ class RemoveSpanHandler(xml.sax.handler.ContentHandler):
             self.content.write("/>")
             self.start_tag_open = False
         else:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def get_content(self) -> str:
         return self.content.getvalue()
@@ -76,7 +76,7 @@ class RemoveSpanHandler(xml.sax.handler.ContentHandler):
         self.locator = locator
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if self.start_tag_open:
@@ -99,7 +99,7 @@ class RemoveSpanHandler(xml.sax.handler.ContentHandler):
                     #logging.info(f"removing span: {span_style_name}")
                     return  # remove this tag
         self.start_tag_open = True
-        self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
 
 class RemoveSpanTags:

--- a/scripts/python/src/fodt/set_fonts.py
+++ b/scripts/python/src/fodt/set_fonts.py
@@ -4,8 +4,7 @@ import click
 
 from pathlib import Path
 from fodt.constants import ClickOptions, Directories, TagEvent
-from fodt import helpers
-from fodt.xml_helpers import XMLHelper
+from fodt import helpers, xml_helpers
 import xml.sax
 import xml.sax.handler
 import xml.sax.xmlreader
@@ -35,24 +34,24 @@ class ItemHandler(xml.sax.handler.ContentHandler):
             self.in_section = True
             self.insert_font_decls()
         if not self.in_section:
-            self.content.write(XMLHelper.starttag(name, attrs))
+            self.content.write(xml_helpers.starttag(name, attrs))
 
     def endElement(self, name: str):
         if not self.in_section:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
         if name == self.font_tag_name:
             self.in_section = False
 
     def characters(self, content: str):
         if not self.in_section:
-            self.content.write(XMLHelper.escape(content))
+            self.content.write(xml_helpers.escape(content))
 
     def write_file(self):
         with open(self.savename, "w", encoding='utf-8') as f:
             f.write(self.content.getvalue())
 
     def write_xml_header(self) -> None:
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
 class ReplaceFontDecls():
     def __init__(self, filename: str, savename: str, font_decl_file: str) -> None:

--- a/scripts/python/src/fodt/split_git_commit.py
+++ b/scripts/python/src/fodt/split_git_commit.py
@@ -15,7 +15,7 @@ import click
 from git import Repo
 
 from fodt.extract_xml_tag import ExtractXmlTag
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class ContentHandler(xml.sax.handler.ContentHandler):
     def __init__(self, old_body: str) -> None:
@@ -31,14 +31,14 @@ class ContentHandler(xml.sax.handler.ContentHandler):
             self.in_body = False
         else:
             if not self.in_body:
-                self.content.write(XMLHelper.endtag(name))
+                self.content.write(xml_helpers.endtag(name))
 
     def characters(self, content: str):
         if not self.in_body:
             self.content.write(xml.sax.saxutils.escape(content))
 
     def startDocument(self):
-        self.content.write(XMLHelper.header)
+        self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name: str, attrs: xml.sax.xmlreader.AttributesImpl):
         if name == 'office:body':
@@ -47,7 +47,7 @@ class ContentHandler(xml.sax.handler.ContentHandler):
             self.content.write(self.body)
         else:
             if not self.in_body:
-                self.content.write(XMLHelper.starttag(name, attrs))
+                self.content.write(xml_helpers.starttag(name, attrs))
 
 
 class Splitter:

--- a/scripts/python/src/fodt/split_main.py
+++ b/scripts/python/src/fodt/split_main.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import fodt.string_functions
 from fodt.constants import ClickOptions, Directories, FileNames
 from fodt.remove_chapters import RemoveChapters
-from fodt.xml_helpers import XMLHelper
+from fodt.xml_helpers import xml_helper
 
 class ElementHandler(xml.sax.handler.ContentHandler):
     def __init__(self) -> None:
@@ -23,7 +23,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
         self.nesting = 0
 
     def characters(self, content: str):
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def check_correct_table(self, attrs: xml.sax.xmlreader.AttributesImpl) -> bool:
         keys = attrs.keys()
@@ -40,7 +40,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
             elif name == "text:bookmark-ref":
                 # remove this tag
                 return
-        self.content.write(XMLHelper.endtag(name))
+        self.content.write(xml_helpers.endtag(name))
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         # logging.info(f"startElement: {name}")
@@ -50,7 +50,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
         if self.in_table and name == "text:bookmark-ref":
             # remove this tag
             return
-        self.content.write(XMLHelper.starttag(name, attrs))
+        self.content.write(xml_helpers.starttag(name, attrs))
 
 
 class FixupMasterStyles():

--- a/scripts/python/src/fodt/styles_filter.py
+++ b/scripts/python/src/fodt/styles_filter.py
@@ -8,7 +8,7 @@ import xml.sax.saxutils
 
 from pathlib import Path
 from fodt.constants import AutomaticStyles, FileNames, FileExtensions
-from fodt.xml_helpers import XMLHelper
+from fodt.xml_helpers import xml_helper
 
 class ElementHandler(xml.sax.handler.ContentHandler):
     def __init__(self, part: str) -> None:
@@ -19,7 +19,7 @@ class ElementHandler(xml.sax.handler.ContentHandler):
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         self.content.write(f"<{name}")
         for (key, value) in attrs.items():
-            evalue = XMLHelper.escape(value)
+            evalue = xml_helpers.escape(value)
             self.content.write(f" {key}=\"{evalue}\"")
         if name == "text:outline-level-style":
             level = int(attrs.getValue("text:level"))
@@ -31,10 +31,10 @@ class ElementHandler(xml.sax.handler.ContentHandler):
         self.content.write(">")
 
     def endElement(self, name: str):
-        self.content.write(XMLHelper.endtag(name))
+        self.content.write(xml_helpers.endtag(name))
 
     def characters(self, content: str):
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
 class StylesFilter:
     def __init__(self, content: str, part: str) -> None:

--- a/scripts/python/src/fodt/xml_handlers.py
+++ b/scripts/python/src/fodt/xml_handlers.py
@@ -5,7 +5,7 @@ import xml.sax.handler
 import xml.sax.xmlreader
 import xml.sax.saxutils
 
-from fodt.xml_helpers import XMLHelper
+from fodt import xml_helpers
 
 class PassThroughFilterHandler(xml.sax.handler.ContentHandler):
     def __init__(self, add_header=True) -> None:
@@ -19,27 +19,27 @@ class PassThroughFilterHandler(xml.sax.handler.ContentHandler):
             # tag and the end tag. If there is no content, characters() is not called.
             self.content.write(">")
             self.start_tag_open = False
-        self.content.write(XMLHelper.escape(content))
+        self.content.write(xml_helpers.escape(content))
 
     def endElement(self, name: str):
         if self.start_tag_open:
             self.content.write("/>")
             self.start_tag_open = False
         else:
-            self.content.write(XMLHelper.endtag(name))
+            self.content.write(xml_helpers.endtag(name))
 
     def get_content(self) -> str:
         return self.content.getvalue()
 
     def startDocument(self):
         if self.add_header:
-            self.content.write(XMLHelper.header)
+            self.content.write(xml_helpers.HEADER)
 
     def startElement(self, name:str, attrs: xml.sax.xmlreader.AttributesImpl):
         if self.start_tag_open:
             self.content.write(">")
         self.start_tag_open = True
-        self.content.write(XMLHelper.starttag(name, attrs, close_tag=False))
+        self.content.write(xml_helpers.starttag(name, attrs, close_tag=False))
 
 
 class GetUsedStylesHandler(xml.sax.handler.ContentHandler):

--- a/scripts/python/src/fodt/xml_helpers.py
+++ b/scripts/python/src/fodt/xml_helpers.py
@@ -3,37 +3,34 @@ from pathlib import Path
 
 from fodt.constants import FileNames
 
-class XMLHelper(object):
-    header = """<?xml version="1.0" encoding="UTF-8"?>\n"""
-    # NOTE: xml.sax.saxutils.escape() escapes only the three characters
-    # "&", "<", ">". But LibreOffice also escapes the characters '"', "'" so
-    # we need to escape them as well in order to not get large PR diffs when
-    # modifying the .fodt files sometimes with a script and sometimes with
-    # LibreOffice.
-    escape_map = {'"': '&quot;', "'": '&apos;'}
-    @staticmethod
-    def endtag(name: str) -> str:
-        return f"</{name}>"
+HEADER = """<?xml version="1.0" encoding="UTF-8"?>\n"""
 
-    @staticmethod
-    def escape(content: str) -> str:
-        return xml.sax.saxutils.escape(content, XMLHelper.escape_map)
+# NOTE: xml.sax.saxutils.escape() escapes only the three characters
+# "&", "<", ">". But LibreOffice also escapes the characters '"', "'" so
+# we need to escape them as well in order to not get large PR diffs when
+# modifying the .fodt files sometimes with a script and sometimes with
+# LibreOffice.
+ESCAPE_MAP = {'"': '&quot;', "'": '&apos;'}
 
-    @staticmethod
-    def get_office_document_start_tag(metadir: Path) -> None:
-        fn = metadir / FileNames.office_attr_fn
-        with open(fn, "r", encoding='utf-8') as f:
-            attrs = f.read()
-        attrs = attrs.replace("\n", " ")
-        tag = "<office:document " + attrs + ">\n"
-        return tag
+def endtag(name: str) -> str:
+    return f"</{name}>"
 
-    @staticmethod
-    def starttag(name: str, attrs: dict[str, str], close_tag: bool = True) -> str:
-        result = f"<{name}"
-        for (key, value) in attrs.items():
-            evalue = XMLHelper.escape(value)
-            result += f" {key}=\"{evalue}\""
-        if close_tag:
-            result += ">"
-        return result
+def escape(content: str) -> str:
+    return xml.sax.saxutils.escape(content, ESCAPE_MAP)
+
+def get_office_document_start_tag(metadir: Path) -> None:
+    fn = metadir / FileNames.office_attr_fn
+    with open(fn, "r", encoding='utf-8') as f:
+        attrs = f.read()
+    attrs = attrs.replace("\n", " ")
+    tag = "<office:document " + attrs + ">\n"
+    return tag
+
+def starttag(name: str, attrs: dict[str, str], close_tag: bool = True) -> str:
+    result = f"<{name}"
+    for (key, value) in attrs.items():
+        evalue = escape(value)
+        result += f" {key}=\"{evalue}\""
+    if close_tag:
+        result += ">"
+    return result


### PR DESCRIPTION
Remove class `XMLHelpers` and instead use the module `xml_helpers`. This avoids using static class functions and is a more Pythonic way of writing the same code.