### PR TITLE
Update keyword linking script to handle table captions

### DIFF
--- a/scripts/python/src/fodt/keyword_uri_map_generator.py
+++ b/scripts/python/src/fodt/keyword_uri_map_generator.py
@@ -12,7 +12,6 @@ import click
 from fodt.constants import ClickOptions, Directories, FileNames, FileExtensions
 from fodt.exceptions import HandlerDoneException, ParsingException
 from fodt import helpers
-from fodt import xml_helpers
 
 class ExtractURI_Handler(xml.sax.handler.ContentHandler):
     def __init__(self, keyword_name: str) -> None:


### PR DESCRIPTION
Builds on #465  which should be merged first.

We would like to avoid linking keywords in table captions, see https://github.com/OPM/opm-reference-manual/pull/470#issuecomment-2580490968 for more information.