### PR TITLE
ACTNUM keyword example typo and reword

### DIFF
--- a/parts/chapters/subsections/6.3/ACTNUM.fodt
+++ b/parts/chapters/subsections/6.3/ACTNUM.fodt
@@ -4221,6 +4221,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
       </table:table-cell>
       <table:table-cell table:style-name="Table16.A2" office:value-type="string">
        <text:p text:style-name="P1943">An array of integers equal to either 0 or 1 that define the activity of each cell in the model. A value of 0 indicates the cell is inactive.</text:p>
+       <text:p text:style-name="P1943">Grid blocks are ordered with the I index cycling fastest, followed by the J and K indices.</text:p>
        <text:p text:style-name="P1943">Repeat counts may be used, for example 20*1.</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table16.D2" office:value-type="string">


### PR DESCRIPTION
Replace # with -- for comments in example
Reword to make more consistent with other keywords e.g. PERMX Typo in EQUALS record 2