### PR TITLE
Partially reverting PR583

### DIFF
--- a/parts/appendices/E.fodt
+++ b/parts/appendices/E.fodt
@@ -21511,7 +21511,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P674">--ilu-redblack</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table4.C53" office:value-type="string">
-       <text:p text:style-name="_40_Table_20_Contents">A boolean value that instructs OPM Flow to use red-black partitioning for the ILU preconditioner.</text:p>
+       <text:p text:style-name="_40_Table_20_Contents">A boolean value that instructs OPM Flow to use red-black partitioning for the ILU preconditioner. (true) or not (false).</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table4.D53" office:value-type="string">
        <text:p text:style-name="P300">false</text:p>
@@ -24532,7 +24532,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P674">--ilu-redblack</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table3_5f_1.C54" office:value-type="string">
-       <text:p text:style-name="_40_Table_20_Contents">A boolean value that instructs OPM Flow to use red-black partitioning for the ILU preconditioner.</text:p>
+       <text:p text:style-name="_40_Table_20_Contents">A boolean value that instructs OPM Flow to use red-black partitioning for the ILU preconditioner. (true) or not (false).</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table3_5f_1.D54" office:value-type="string">
        <text:p text:style-name="P300">false</text:p>
@@ -27318,7 +27318,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P674">--ilu-redblack</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table2_5f_1.C51" office:value-type="string">
-       <text:p text:style-name="_40_Table_20_Contents">A boolean value that instructs OPM Flow to use red-black partitioning for the ILU preconditioner.</text:p>
+       <text:p text:style-name="_40_Table_20_Contents">A boolean value that instructs OPM Flow to use red-black partitioning for the ILU preconditioner. (true) or not (false).</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table2_5f_1.D51" office:value-type="string">
        <text:p text:style-name="P300">false</text:p>
@@ -29876,7 +29876,7 @@ Updated with AFR/TSA Rev-D comments and new keywords.</dc:description><meta:init
        <text:p text:style-name="P671">--ilu-redblack</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table621.C27" office:value-type="string">
-       <text:p text:style-name="P960">A boolean value that instructs OPM Flow to use red-black partitioning for the ILU preconditioner.</text:p>
+       <text:p text:style-name="P960">A boolean value that instructs OPM Flow to use red-black partitioning for the ILU preconditioner. (true) or not (false).</text:p>
       </table:table-cell>
       <table:table-cell table:style-name="Table621.D41" office:value-type="string">
        <text:p text:style-name="P299">false</text:p>


### PR DESCRIPTION
I was trying to export the pdf manual and I was not able to do so until I partially revert https://github.com/OPM/opm-reference-manual/pull/583 (i.e., without this PR LibreOffice will show after updating the links the app is not responding).

Ubuntu 24.04.3 LTS

LibreOffice
Version: 24.2.7.2 (X86_64) / LibreOffice Community
Build ID: 420(Build:2)
CPU threads: 12; OS: Linux 6.8; UI render: default; VCL: gtk3
Locale: en-US (en_US.UTF-8); UI: en-US
Ubuntu package version: 4:24.2.7-0ubuntu0.24.04.4
Calc: threaded

Does anyone else with that version of Ubuntu and LibreOffice manage to build the manual? 
I still cannot understand the issue.