### PR TITLE
Bump GitPython to 3.1.47 to fix two security advisories

### DIFF
--- a/scripts/python/poetry.lock
+++ b/scripts/python/poetry.lock
@@ -173,21 +173,22 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.42"
+version = "3.1.47"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "GitPython-3.1.42-py3-none-any.whl", hash = "sha256:1bf9cd7c9e7255f77778ea54359e54ac22a72a5b51288c457c881057b7bb9ecd"},
-    {file = "GitPython-3.1.42.tar.gz", hash = "sha256:2d99869e0fef71a73cbd242528105af1d6c1b108c60dfabd994bf292f76c3ceb"},
+    {file = "gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905"},
+    {file = "gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd"},
 ]
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
 
 [package.extras]
-test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar"]
+doc = ["sphinx (>=7.4.7,<8)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy (==1.18.2) ; python_version >= \"3.9\"", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
 
 [[package]]
 name = "idna"


### PR DESCRIPTION
Bumps `GitPython` from 3.1.42 to 3.1.47 in `scripts/python/poetry.lock` to address two high-severity Dependabot alerts. Both are first patched in the same release, so a single bump closes both. The existing `gitpython = "^3.1.42"` constraint in `pyproject.toml` already permits 3.1.47, so only the lockfile changes.

#### Advisories addressed

- **[GHSA-rpm5-65cw-6hj4](https://github.com/OPM/opm-reference-manual/security/dependabot/28)** (CVSS 8.8, CWE-78) — **command injection** via underscore-form `upload_pack=` / `receive_pack=` kwargs that bypass the unsafe-option check in `Repo.clone_from()` and `Remote.fetch/pull/push()`.
- **[GHSA-x2qx-6953-8485](https://github.com/OPM/opm-reference-manual/security/dependabot/29)** (CVSS 8.1, CWE-88) — **argument injection**: `multi_options` is validated before `shlex.split`, allowing a string like `"--branch main --config core.hooksPath=..."` to slip past the check and inject `--config` once split.

#### Test plan

- `poetry update gitpython` — lockfile updated to 3.1.47, no other entries changed (5 insertions / 4 deletions, all inside the `gitpython` block).
- `poetry install` succeeds.
- `poetry run pytest` — all 14 tests pass.
