### PR TITLE
Clear the five Dependabot alerts in `docker/poetry.lock`

### DIFF
--- a/docker/poetry.lock
+++ b/docker/poetry.lock
@@ -236,42 +236,58 @@ files = [
 
 [[package]]
 name = "pluggy"
-version = "1.4.0"
+version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pluggy-1.4.0-py3-none-any.whl", hash = "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981"},
-    {file = "pluggy-1.4.0.tar.gz", hash = "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"},
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
 ]
 
 [package.extras]
 dev = ["pre-commit", "tox"]
-testing = ["pytest", "pytest-benchmark"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.0.0"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.0.0-py3-none-any.whl", hash = "sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6"},
-    {file = "pytest-8.0.0.tar.gz", hash = "sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=1.3.0,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-mock"
@@ -347,4 +363,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "58fdfb48afcba14d5dc3af9bae45d286a6d9c219f12eeac7afb7f3c22d366ca8"
+content-hash = "3311c4add34fd97f692502cdccd694f0c6481f94a2d88843d70fff19788dbd4c"

--- a/docker/poetry.lock
+++ b/docker/poetry.lock
@@ -293,25 +293,25 @@ dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "requests"
-version = "2.32.2"
+version = "2.34.2"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "requests-2.32.2-py3-none-any.whl", hash = "sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c"},
-    {file = "requests-2.32.2.tar.gz", hash = "sha256:dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289"},
+    {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
+    {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
 ]
 
 [package.dependencies]
-certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<4"
+certifi = ">=2023.5.7"
+charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<3"
+urllib3 = ">=1.26,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
 name = "tomli"

--- a/docker/poetry.lock
+++ b/docker/poetry.lock
@@ -2,14 +2,14 @@
 
 [[package]]
 name = "certifi"
-version = "2023.11.17"
+version = "2026.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "certifi-2023.11.17-py3-none-any.whl", hash = "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"},
-    {file = "certifi-2023.11.17.tar.gz", hash = "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"},
+    {file = "certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775"},
+    {file = "certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55"},
 ]
 
 [[package]]

--- a/docker/poetry.lock
+++ b/docker/poetry.lock
@@ -157,15 +157,18 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "idna"
-version = "3.7"
+version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
-    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
+    {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
+    {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
+
+[package.extras]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"

--- a/docker/pyproject.toml
+++ b/docker/pyproject.toml
@@ -21,7 +21,7 @@ lodocker-run-container = "lodocker.docker_run:run_container"
 lodocker-start-container = "lodocker.docker_start:start_container"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.0.0"
+pytest = "^9.0.3"
 pytest-mock = "^3.12.0"
 
 [build-system]


### PR DESCRIPTION
One of two PRs closing [the 29 open Dependabot alerts](https://github.com/OPM/opm-reference-manual/security/dependabot) on this repository. This one covers the `lodocker` project under `docker/`; a companion PR covers the `fodt` project under `scripts/python/`. The two touch disjoint directories and can be merged in either order.

Each bump is a **targeted** relock — one `poetry update --lock <pkg>` per affected package — so only the packages that actually need to move do. A full `poetry update` would have rewritten the whole resolution for no additional security benefit.

Version delta versus `main`:

| Package | Before | After | |
|---------|--------|-------|---|
| certifi | 2023.11.17 | 2026.7.22 | |
| idna | 3.7 | 3.18 | |
| requests | 2.32.2 | 2.34.2 | |
| pytest | 8.0.0 | 9.1.1 | |
| pluggy | 1.4.0 | 1.6.0 | pytest 9 dependency |
| pygments | — | 2.20.0 | new pytest 9 dependency |

`pluggy` and `pygments` are not incidental drift: pytest 9 requires them. Everything else in the lock — `click`, `colorama`, `netifaces`, `charset-normalizer`, `urllib3` — is untouched.

#### Bump certifi to 2026.7.22 (commit 1)

- Fixes alert #9, `GHSA-248v-346w-9cwc` (CVE-2024-39689): the **GLOBALTRUST root certificate** was removed from the trust store after the CA was found to have issued certificates in violation of the baseline requirements.
- The lock was still carrying the **2023.11.17** CA bundle. `certifi` is a transitive dependency of `requests`.

#### Bump idna to 3.18 (commit 2)

- Fixes alert #39, `GHSA-65pc-fj4g-8rjx` (CVE-2026-45409): specially crafted input to `idna.encode()` **bypasses the CVE-2024-3651 fix**, allowing excessive resource consumption.
- Transitive dependency of `requests`.

#### Bump requests to 2.34.2 (commit 3)

- Fixes alerts #12 and #25 — two advisories had stacked up on the pinned 2.32.2:
  - `GHSA-9hjg-9r4m-mvj7` (CVE-2024-47081): **`.netrc` credentials leaked** to a third party through a maliciously crafted URL.
  - `GHSA-gc5v-m9x4-r6x2` (CVE-2026-25645): **insecure temporary file reuse** in the `extract_zipped_paths()` utility function.

#### Bump pytest to 9.1.1 (commit 4)

- Fixes alert #26, `GHSA-6w46-j5rx-g56g` (CVE-2025-71176): **insecure handling of the per-user temporary directory**, which is reused across runs and can be pre-created by another local user.
- This is the **only commit that touches `pyproject.toml`** — the fix first landed in pytest 9.0.3, so the dev constraint moves from `^8.0.0` to `^9.0.3`. Every other bump is lock-only.
- `pytest-mock` 3.12.0 requires only `pytest >= 6.2.5` and is unaffected.

### Verification

`cd docker && poetry install && poetry run pytest tests` → **12 passed**, run on this branch.

Please note that **CI will not run on this PR**. The `ci.yml` path filter covers `scripts/python/**` and `scripts/docker/**`, but the Docker project lives at `docker/` — so no workflow triggers on these changes and the local test run above is the only gate. Fixing that filter is worth a follow-up of its own.
