### PR TITLE
Clear the 24 Dependabot alerts in `scripts/python`

### DIFF
--- a/scripts/python/poetry.lock
+++ b/scripts/python/poetry.lock
@@ -192,15 +192,18 @@ test = ["basedpyright (==1.39.9) ; python_version >= \"3.9\" and sys_platform !=
 
 [[package]]
 name = "idna"
-version = "3.7"
+version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
-    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
+    {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
+    {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
+
+[package.extras]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"

--- a/scripts/python/poetry.lock
+++ b/scripts/python/poetry.lock
@@ -173,14 +173,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.58"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9"},
-    {file = "gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc"},
+    {file = "gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f"},
+    {file = "gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22"},
 ]
 
 [package.dependencies]
@@ -188,7 +188,7 @@ gitdb = ">=4.0.1,<5"
 
 [package.extras]
 doc = ["sphinx (>=7.4.7,<8)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
-test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy (==1.18.2) ; python_version >= \"3.9\"", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
+test = ["basedpyright (==1.39.9) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy (==1.18.2) ; python_version >= \"3.9\"", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
 
 [[package]]
 name = "idna"

--- a/scripts/python/poetry.lock
+++ b/scripts/python/poetry.lock
@@ -231,42 +231,58 @@ files = [
 
 [[package]]
 name = "pluggy"
-version = "1.4.0"
+version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pluggy-1.4.0-py3-none-any.whl", hash = "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981"},
-    {file = "pluggy-1.4.0.tar.gz", hash = "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"},
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
 ]
 
 [package.extras]
 dev = ["pre-commit", "tox"]
-testing = ["pytest", "pytest-benchmark"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.0.1"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pytest-8.0.1-py3-none-any.whl", hash = "sha256:3e4f16fe1c0a9dc9d9389161c127c3edc5d810c38d6793042fb81d9f48a59fca"},
-    {file = "pytest-8.0.1.tar.gz", hash = "sha256:267f6563751877d772019b13aacbe4e860d73fe8f651f28112e9ac37de7513ae"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=1.3.0,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-mock"
@@ -354,4 +370,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "70909acdefd6fd30bcbc2769c7e0aa12884e5fcd00091832b822bbd313c20f4e"
+content-hash = "cc42b17f32d905f5287489e2927e3846508abf099ebdff736104ba2050e9f855"

--- a/scripts/python/poetry.lock
+++ b/scripts/python/poetry.lock
@@ -288,25 +288,25 @@ dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "requests"
-version = "2.31.0"
+version = "2.34.2"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
-    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+    {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
+    {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
 ]
 
 [package.dependencies]
-certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<4"
+certifi = ">=2023.5.7"
+charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<3"
+urllib3 = ">=1.26,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
 name = "smmap"

--- a/scripts/python/pyproject.toml
+++ b/scripts/python/pyproject.toml
@@ -11,7 +11,7 @@ python = "^3.10"
 click = "^8.1.7"
 requests = "^2.31.0"
 gitpython = "^3.1.42"
-pytest = "^8.0.1"
+pytest = "^9.0.3"
 pytest-mock = "^3.12.0"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
The second of two PRs closing [the 29 open Dependabot alerts](https://github.com/OPM/opm-reference-manual/security/dependabot) on this repository. This one covers the `fodt` project under `scripts/python/`; #767 covers the `lodocker` project under `docker/`. The two touch disjoint directories and can be merged in either order.

Each bump is a **targeted** relock — one `poetry update --lock <pkg>` per affected package — so only the packages that actually need to move do. A full `poetry update` would have rewritten the whole resolution for no additional security benefit.

Version delta versus `main`:

| Package | Before | After | |
|---------|--------|-------|---|
| GitPython | 3.1.50 | 3.1.58 | |
| idna | 3.7 | 3.18 | |
| requests | 2.31.0 | 2.34.2 | |
| pytest | 8.0.1 | 9.1.1 | |
| pluggy | 1.4.0 | 1.6.0 | pytest 9 dependency |
| pygments | — | 2.20.0 | new pytest 9 dependency |

`pluggy` and `pygments` are not incidental drift: pytest 9 requires them. Everything else in the lock — `click`, `colorama`, `certifi`, `charset-normalizer`, `urllib3` — is untouched.

#### Bump GitPython to 3.1.58 (commit 1)

- Fixes **18 of the 24 alerts** (#40–#57) in one hop. Between 2026-07-21 and 2026-08-07 a campaign of argument-injection findings was published against GitPython, each patched in an incremental 3.1.x release.
- Covers **unguarded git option forwarding** enabling arbitrary file read/overwrite or command execution via clone and checkout hooks (`GHSA-956x-8gvw-wg5v`, `GHSA-6p8h-3wgx-97gf`, `GHSA-fjr4-x663-mwxc`, `GHSA-3f7w-8rr8-f37f`, `GHSA-4gmw-gg2m-w46p`, `GHSA-9rj7-rf2p-w77r`, `GHSA-hh9p-6wh2-4mfc`, `GHSA-539m-9xh6-q6rr`, `GHSA-p538-c434-8v24`); **denylist bypasses** through option abbreviation, joined short options and single-character token smuggling (`GHSA-v396-v7q4-x2qj`, `GHSA-2f96-g7mh-g2hx`, `GHSA-r9mr-m37c-5fr3`, `GHSA-wvpp-8hx9-p66j`); **git-config injection** forging `core.sshCommand` and `core.hooksPath` (`GHSA-3rp5-jjmw-4wv2`, `GHSA-jm78-9fvv-mhgr`); **environment-variable exfiltration** via `expandvars()` on clone and remote URLs (`GHSA-rwj8-pgh3-r573`, `GHSA-94p4-4cq8-9g67`); and **repository creation outside the working tree** via an unvalidated `.gitmodules` submodule name (`GHSA-hmq2-w58f-27jc`).
- **The interesting question here is regressions, not exposure.** `fodt` drives GitPython from real commands rather than test fixtures, but always against the user's own checkout with developer-supplied arguments, so none of these are reachable in practice. What matters is that the same releases tighten the guards on which git options may be forwarded — and several call sites in `src/fodt/split_git_commit.py` sit squarely in the guarded area: `checkout('HEAD', b=...)` (a single-character kwarg, exactly the shape `GHSA-r9mr-m37c-5fr3` addresses), `reset('--soft', 'HEAD~1')`, `diff(branch, 'HEAD')` and `iter_commits('HEAD', max_count=1)` (named in `GHSA-956x-8gvw-wg5v`). All of them are exercised end to end by `tests/test_split_git_commit.py`, which builds a real temporary repository and runs `Splitter.split_commit()`. That suite passes on 3.1.58, so the new guards do not reject the way `fodt` calls git.

#### Bump idna to 3.18 (commit 2)

- Fixes alert #38, `GHSA-65pc-fj4g-8rjx` (CVE-2026-45409): specially crafted input to `idna.encode()` **bypasses the CVE-2024-3651 fix**, allowing excessive resource consumption.
- Transitive dependency of `requests`.

#### Bump requests to 2.34.2 (commit 3)

- Fixes alerts #3, #11 and #24 — the lock was still on 2.31.0, so **three advisories had stacked up**:
  - `GHSA-9wx4-h78v-vm56` (CVE-2024-35195): a `Session` that made its first request with `verify=False` **keeps skipping certificate verification** for every subsequent request to the same host.
  - `GHSA-9hjg-9r4m-mvj7` (CVE-2024-47081): **`.netrc` credentials leaked** to a third party through a maliciously crafted URL.
  - `GHSA-gc5v-m9x4-r6x2` (CVE-2026-25645): **insecure temporary file reuse** in the `extract_zipped_paths()` utility function.

#### Bump pytest to 9.1.1 (commit 4)

- Fixes alerts #27 and #30, `GHSA-6w46-j5rx-g56g` (CVE-2025-71176): **insecure handling of the per-user temporary directory**, which is reused across runs and can be pre-created by another local user.
- This is the **only commit that touches `pyproject.toml`** — the fix first landed in pytest 9.0.3, so the constraint moves from `^8.0.1` to `^9.0.3`. That constraint is what #30 flags directly against the manifest, while #27 covers the pinned version in the lock.
- `pytest-mock` 3.12.0 requires only `pytest >= 6.2.5` and is unaffected.

### Verification

- `cd scripts/python && poetry install && poetry run pytest tests` → **14 passed**, run on this branch.
- Unlike #767, this PR **does** get CI: `ci.yml` reruns the suite on Python 3.10 and 3.11 across Linux, macOS and Windows, and `check_keyword_linking.yml` runs `fodt-gen-kw-uri-map --check-changed` and `fodt-link-keywords --all --check-changed` on 3.12 — a genuine end-to-end exercise of the `fodt` scripts against the upgraded dependencies.
- The lock file stays at `lock-version = "2.1"`, so the Poetry 1.8.4 pin in `check_keyword_linking.yml` is unaffected.
