### PR TITLE
Add Dependabot configuration for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# Dependabot configuration.
+#
+# Without this file GitHub only raises *security* alerts; it never opens
+# version-update pull requests. That is how both Poetry lock files were allowed
+# to drift years behind upstream (see PRs #767 and #768, which together had to
+# clear 29 open alerts, some of them dating back to 2024).
+#
+# Everything is grouped into a single pull request per ecosystem, because
+# ungrouped updates are unmanageable here: GitPython alone went through eight
+# patch releases in the three weeks from 2026-07-21 to 2026-08-07, each of which
+# would have arrived as its own pull request.
+#
+# Note that this file only affects scheduled version updates. Security updates
+# are still opened immediately and individually whenever an advisory is
+# published, independently of the schedule below.
+version: 2
+updates:
+    # The fodt package: chapter splitting, keyword linking and style fixes.
+    # Dependabot needs one entry per manifest directory, which is why the two
+    # Poetry projects are listed separately below.
+    - package-ecosystem: "pip"
+      directory: "/scripts/python"
+      schedule:
+          interval: "monthly"
+      groups:
+          python-dependencies:
+              patterns:
+                  - "*"
+
+    # The lodocker package: building and running the LibreOffice containers.
+    - package-ecosystem: "pip"
+      directory: "/docker"
+      schedule:
+          interval: "monthly"
+      groups:
+          python-dependencies:
+              patterns:
+                  - "*"
+
+    # Workflow action pins. Dependabot can only bump actions referenced by a
+    # version tag, which covers every action used by the two workflows:
+    # actions/checkout, actions/setup-python and abatilo/actions-poetry.
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "monthly"
+      groups:
+          github-actions:
+              patterns:
+                  - "*"


### PR DESCRIPTION
Follow-up to #767 and #768. Those two PRs cleared 29 open Dependabot alerts; this one is about not getting into that situation again.

The repository has no `.github/dependabot.yml`, which means GitHub only ever raises **security alerts** — it never opens routine version-update pull requests. Nothing has been nudging the dependencies forward between advisories, so both lock files drifted badly: `scripts/python` was still on `requests` 2.31.0 with three stacked advisories, and `docker` was carrying a `certifi` CA bundle from 2023 and a `requests` advisory from 2024.

#### What the config does

Three entries, because **Dependabot takes one manifest directory per entry** — the two Poetry projects cannot share one:

- **`pip`, rooted at `/scripts/python`** — the `fodt` package.
- **`pip`, rooted at `/docker`** — the `lodocker` package.
- **`github-actions`, rooted at `/`** — the workflow action pins. Dependabot can only bump actions referenced by a **version tag**, and every action used here qualifies: `actions/checkout`, `actions/setup-python` and `abatilo/actions-poetry`.

All three use a **monthly schedule with a single catch-all group**, so each ecosystem produces at most one pull request per month. Grouping is the important part: ungrouped, GitPython alone went through **eight patch releases in the three weeks from 2026-07-21 to 2026-08-07**, and each would have arrived as a separate pull request.

This affects **scheduled version updates only**. Security updates are unchanged — they are still opened immediately and individually whenever an advisory is published, regardless of the schedule here.

#### What to expect after merging

- The first **github-actions** PR should bring the pins up to date. Both workflows are on `actions/checkout@v3` and `actions/setup-python@v4` (v4 and v5 are current), and `ci.yml` uses `abatilo/actions-poetry@v2` while `check_keyword_linking.yml` is already on `@v3` — worth reviewing together rather than one at a time. Note that `check_keyword_linking.yml` pins `poetry-version: "1.8.4"` with a comment that "latest" did not work, so that pin should be left alone unless it is retested deliberately.
- The first **pip** PRs will be larger than a routine month, since they will carry everything that has accumulated beyond the security fixes just merged.


